### PR TITLE
Fix '//' issue with cygwin $prefix paths.

### DIFF
--- a/src/extensions/perl/Genders/Makefile.am
+++ b/src/extensions/perl/Genders/Makefile.am
@@ -23,7 +23,7 @@ Genders.$(PERLMAN3EXT):
 man3_MANS = Genders.$(PERLMAN3EXT)
 
 install-data-hook:
-	chmod 444 $(DESTDIR)/$(prefix)/$(INSTALLARCH)/Genders.pm
+	chmod 444 $(DESTDIR)$(prefix)/$(INSTALLARCH)/Genders.pm
 endif
 
 EXTRA_DIST = Genders.pm

--- a/src/extensions/perl/Genders/Makefile.in
+++ b/src/extensions/perl/Genders/Makefile.in
@@ -512,7 +512,7 @@ uninstall-man: uninstall-man3
 @WITH_PERL_EXTENSIONS_TRUE@	$(POD2MAN) Genders.pm Genders.$(PERLMAN3EXT)
 
 @WITH_PERL_EXTENSIONS_TRUE@install-data-hook:
-@WITH_PERL_EXTENSIONS_TRUE@	chmod 444 $(DESTDIR)/$(prefix)/$(INSTALLARCH)/Genders.pm
+@WITH_PERL_EXTENSIONS_TRUE@	chmod 444 $(DESTDIR)$(prefix)/$(INSTALLARCH)/Genders.pm
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/src/extensions/python/Makefile.am
+++ b/src/extensions/python/Makefile.am
@@ -17,13 +17,13 @@ all: genderssetup.py libgendersmodule.c genders.py
 	$(PYTHON) genderssetup.py build
 
 install:
-	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)/$(prefix) --exec-prefix=$(PYTHON_DESTDIR)/$(exec_prefix)
+	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 pure_install:
-	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)/$(prefix) --exec-prefix=$(PYTHON_DESTDIR)/$(exec_prefix)
+	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 install-data-local:
-	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)/$(prefix) --exec-prefix=$(PYTHON_DESTDIR)/$(exec_prefix)
+	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 clean: 
 	rm -rf build

--- a/src/extensions/python/Makefile.in
+++ b/src/extensions/python/Makefile.in
@@ -405,13 +405,13 @@ uninstall-am:
 @WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py build
 
 @WITH_PYTHON_EXTENSIONS_TRUE@install:
-@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)/$(prefix) --exec-prefix=$(PYTHON_DESTDIR)/$(exec_prefix)
+@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 @WITH_PYTHON_EXTENSIONS_TRUE@pure_install:
-@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)/$(prefix) --exec-prefix=$(PYTHON_DESTDIR)/$(exec_prefix)
+@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 @WITH_PYTHON_EXTENSIONS_TRUE@install-data-local:
-@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)/$(prefix) --exec-prefix=$(PYTHON_DESTDIR)/$(exec_prefix)
+@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 @WITH_PYTHON_EXTENSIONS_TRUE@clean: 
 @WITH_PYTHON_EXTENSIONS_TRUE@	rm -rf build


### PR DESCRIPTION
Normally the configure --prefix setting is an absolute path.  Two of the genders extension
Makefiles (perl/Genders and python) had an extra slash in front of $prefix.

On Unix systems is is benign; paths that start with '//' are equivalent to paths
that start with '/'.

But on cygwin / ms-windows systems '//' is 'magic', and specified a global network path as
opposed to a host relative path.

I deleted the extra slash in front of $prefix and now 'make install' runs to completion
on cygwin.