### PR TITLE
-A now respects -X exclusions

### DIFF
--- a/src/nodeattr/nodeattr.c
+++ b/src/nodeattr/nodeattr.c
@@ -272,7 +272,7 @@ main(int argc, char *argv[])
         char *query;
 
         if (Aopt)
-            list_nodes(gp, NULL, NULL, qfmt); 
+            list_nodes(gp, NULL, excludequery, qfmt); 
         else {
             query = argv[optind++];
             list_nodes(gp, query, excludequery, qfmt);


### PR DESCRIPTION
fix for TOSS 3190 nodeattr ignores -X when used with -A