### PR TITLE
adding compress-hosts feature

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2017-03-01  Ben Casses <casses1@llnl.gov>
+
+	* src/nodeattr/: Support --compress-hosts option.
+
+	* src/libgenders/: added genders_getflatattrsvals for --compress-hosts
+
 2015-05-07  Albert Chu  <chu11@llnl.gov>
 
 	* Add contrib for dynamic library support in cfengine 3.3.0 from John

--- a/man/nodeattr.1
+++ b/man/nodeattr.1
@@ -61,6 +61,9 @@ nodeattr \- query genders file
 .B nodeattr
 .I "[-f genders] --compress"
 .br
+.B nodeattr
+.I "[-f genders] --compress-hosts"
+.br
 .SH DESCRIPTION
 When invoked with the 
 .I "-q"
@@ -169,6 +172,13 @@ of your genders database, the resulting database may be longer or
 shorter.  This option may be useful as a beginning step to compressing
 an existing genders database.
 .LP
+The 
+.I "--compress-hosts"
+is similar to 
+.I "--compress"
+except that it groups all hosts with identical attribute sets.  Each host will
+only appear on one line of the output.  This is useful for comparing the genders
+of two nodes that are expected to be the same.
 Attribute names may optionally appear in the genders file with an
 equal sign followed by a value.
 .B Nodeattr

--- a/src/libgenders/genders.h.in
+++ b/src/libgenders/genders.h.in
@@ -326,6 +326,18 @@ int genders_getattr(genders_t handle,
  */
 int genders_getattr_all(genders_t handle, char *attrs[], int len);
 
+/*
+ * genders_getflatattrsvals
+ *
+ * Writes all attrs (and "="val where present), as a single, sorted, comma
+ * delimited, null terminated string to output_string.
+ *
+ * Caller is responsible for providing an output_string long enough.
+ *
+ * Returns number of attributes on success, -1 on failure
+ */
+int genders_getflatattrsvals(genders_t gp, char *node, char *output_string);
+
 /* 
  * genders_testattr
  *


### PR DESCRIPTION
new feature : --compress-hosts or -H : compress in the other direction, search by hosts instead of attrs output has each host appearing only once.