### PR TITLE
Fix genders_nodelist_destroy.3 man page

### DIFF
--- a/man/genders_nodelist_destroy.3
+++ b/man/genders_nodelist_destroy.3
@@ -23,4 +23,4 @@
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
-.so man3/genders_nodelist_destroy.3
+.so man3/genders_nodelist_create.3


### PR DESCRIPTION
Prior to this it tried to recursively link to itself, leading to:
/usr/share/man/man3/genders_nodelist_destroy.3:27: can't open `man3/genders_nodelist_destroy.3': No such file or directory

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>