### PR TITLE
remove trailing whitespace

### DIFF
--- a/config/ac_cplusplus_extensions.m4
+++ b/config/ac_cplusplus_extensions.m4
@@ -6,7 +6,7 @@ AC_DEFUN([AC_CPLUSPLUS_EXTENSIONS],
 [
   AC_MSG_CHECKING(for --with-cplusplus-extensions)
   AC_ARG_WITH(cplusplus-extensions,
-     AS_HELP_STRING([--with-cplusplus-extensions=], 
+     AS_HELP_STRING([--with-cplusplus-extensions=],
                     [enable or disable c++ extensions build]),
      [ case "$withval" in
      yes)

--- a/config/ac_extension_destdir.m4
+++ b/config/ac_extension_destdir.m4
@@ -8,7 +8,7 @@ AC_DEFUN([AC_EXTENSION_DESTDIR],
 [
   AC_MSG_CHECKING(for --with-extension-destdir )
   AC_ARG_WITH(extension-destdir,
-     AS_HELP_STRING([--with-extension-destdir=path], 
+     AS_HELP_STRING([--with-extension-destdir=path],
                     [define extension modules install prefix]),
      [ case "$withval" in
      yes)

--- a/config/ac_genders_file.m4
+++ b/config/ac_genders_file.m4
@@ -7,12 +7,12 @@ AC_DEFUN([AC_GENDERS_FILE],
   GENDERS_DEFAULT_FILE="\"/etc/genders\""
   AC_MSG_CHECKING([for genders default file path])
   AC_ARG_WITH([genders-file],
-    AS_HELP_STRING([--with-genders-file=PATH], 
+    AS_HELP_STRING([--with-genders-file=PATH],
                    [define default genders file]),
     [ case "$withval" in
         no)  ;;
         yes) ;;
-        *)   GENDERS_DEFAULT_FILE="\"$withval\"" 
+        *)   GENDERS_DEFAULT_FILE="\"$withval\""
       esac
     ]
   )

--- a/config/ac_java_extensions.m4
+++ b/config/ac_java_extensions.m4
@@ -6,7 +6,7 @@ AC_DEFUN([AC_JAVA_EXTENSIONS],
 [
   AC_MSG_CHECKING(for --with-java-extensions)
   AC_ARG_WITH(java-extensions,
-     AS_HELP_STRING([--with-java-extensions=], 
+     AS_HELP_STRING([--with-java-extensions=],
                     [enable or disable java extensions build]),
      [ case "$withval" in
      yes)

--- a/config/ac_perl_extensions.m4
+++ b/config/ac_perl_extensions.m4
@@ -9,7 +9,7 @@ AC_DEFUN([AC_PERL_EXTENSIONS],
 [
   AC_MSG_CHECKING(for --with-perl-extensions)
   AC_ARG_WITH(perl-extensions,
-     AS_HELP_STRING([--with-perl-extensions=], 
+     AS_HELP_STRING([--with-perl-extensions=],
                     [enable or disable perl extensions build]),
      [ case "$withval" in
      yes)

--- a/config/ac_perl_site_arch.m4
+++ b/config/ac_perl_site_arch.m4
@@ -6,7 +6,7 @@ AC_DEFUN([AC_PERL_SITE_ARCH],
 [
   AC_MSG_CHECKING(for --with-perl-site-arch)
   AC_ARG_WITH(perl-site-arch,
-     AS_HELP_STRING([--with-perl-site-arch=], 
+     AS_HELP_STRING([--with-perl-site-arch=],
                     [enable or disable perl extensions install in site arch]),
      [ case "$withval" in
      yes)

--- a/config/ac_perl_vendor_arch.m4
+++ b/config/ac_perl_vendor_arch.m4
@@ -6,7 +6,7 @@ AC_DEFUN([AC_PERL_VENDOR_ARCH],
 [
   AC_MSG_CHECKING(for --with-perl-vendor-arch)
   AC_ARG_WITH(perl-vendor-arch,
-     AS_HELP_STRING([--with-perl-vendor-arch=], 
+     AS_HELP_STRING([--with-perl-vendor-arch=],
                     [enable or disable perl extensions install in vendor arch]),
      [ case "$withval" in
      yes)

--- a/config/ac_python_extensions.m4
+++ b/config/ac_python_extensions.m4
@@ -6,7 +6,7 @@ AC_DEFUN([AC_PYTHON_EXTENSIONS],
 [
   AC_MSG_CHECKING(for --with-python-extensions)
   AC_ARG_WITH(python-extensions,
-     AS_HELP_STRING([--with-python-extensions=], 
+     AS_HELP_STRING([--with-python-extensions=],
                     [enable or disable python extensions build]),
      [ case "$withval" in
      yes)

--- a/contrib/cfengine/genders.c
+++ b/contrib/cfengine/genders.c
@@ -16,7 +16,7 @@ static int genders_file_exists (const char *genders_file)
 	if (genders_file == NULL)
 		genders_file = GENDERS_DEFAULT_FILE;
 
-	if ((stat (genders_file, &st) < 0) && 
+	if ((stat (genders_file, &st) < 0) &&
 		((errno == ENOENT) || (errno == ENOTDIR)))
 		return 0;
 

--- a/contrib/php/config.m4
+++ b/contrib/php/config.m4
@@ -35,7 +35,7 @@ if test "$PHP_GENDERS" != "no"; then
       done
     fi
   fi
- 
+
   if test -z "$GENDERS_DIR"; then
     AC_MSG_RESULT([not found])
     AC_MSG_ERROR([Please reinstall the genders distribution])
@@ -55,7 +55,7 @@ if test "$PHP_GENDERS" != "no"; then
   ],[
     -L$GENDERS_DIR/lib -lm -ldl
   ])
- 
+
   PHP_SUBST(GENDERS_SHARED_LIBADD)
 
   PHP_NEW_EXTENSION(genders, genders.c, $ext_shared)

--- a/contrib/php/genders.c
+++ b/contrib/php/genders.c
@@ -52,7 +52,7 @@ zend_module_entry genders_module_entry = {
 	genders_functions,
 	PHP_MINIT(genders),
 	PHP_MSHUTDOWN(genders),
-	PHP_RINIT(genders),	
+	PHP_RINIT(genders),
 	PHP_RSHUTDOWN(genders),
 	PHP_MINFO(genders),
 	NO_VERSION_YET,

--- a/man/genders.3
+++ b/man/genders.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_attrlist_clear.3
+++ b/man/genders_attrlist_clear.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_attrlist_create.3
+++ b/man/genders_attrlist_create.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.

--- a/man/genders_attrlist_destroy.3
+++ b/man/genders_attrlist_destroy.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_errnum.3
+++ b/man/genders_errnum.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_errormsg.3
+++ b/man/genders_errormsg.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_getattr.3
+++ b/man/genders_getattr.3
@@ -6,26 +6,26 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
 .TH GENDERS_GETATTR 3 "August 2003" "LLNL" "LIBGENDERS"
 .SH NAME
-genders_getattr \- get attributes from a genders file 
+genders_getattr \- get attributes from a genders file
 .SH SYNOPSIS
 .B #include <genders.h>
 .sp
@@ -46,7 +46,7 @@ attributes and attribute values,
 .BR genders_getmaxattrs (3)
 should be used to determine the minimum number of elements \fIattrs\fR
 and \fIvals\fR should be able to store.
-.BR genders_attrlist_create (3) 
+.BR genders_attrlist_create (3)
 and
 .BR genders_vallist_create (3)
 could be used to create lists that are guaranteed to be large enough
@@ -57,8 +57,8 @@ On success, the number of attributes stored in \fIattrs\fR is
 returned.  On error, -1 is returned, and an error code is returned in
 \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -77,7 +77,7 @@ The list pointed to by \fIattrs\fR or \fIvals\fR is not large enough
 to store all the attributes or attribute values.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_NULLPTR
 A null pointer has been found in the list passed in.
@@ -87,7 +87,7 @@ The node pointed to by \fInode\fR cannot be found in the genders file
 or if \fInode\fR=NULL, the machine genders is running on is not listed
 in the genders database.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_getattr_all.3
+++ b/man/genders_getattr_all.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -43,7 +43,7 @@ attributes,
 .BR genders_getnumattrs (3)
 should be used to determine the minimum number of elements \fIattrs\fR
 should be able to store.
-.BR genders_attrlist_create (3) 
+.BR genders_attrlist_create (3)
 could be used to create a list that is guaranteed to be large enough
 to store all attributes.
 .br
@@ -52,8 +52,8 @@ On success, the number of attributes stored in \fIattrs\fR is
 returned.  On error, -1 is returned, and an error code is returned in
 \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -72,12 +72,12 @@ The list pointed to by \fIattrs\fR is not large enough to store all
 the attributes.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_NULLPTR
 A null pointer has been found in the list passed in.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_getmaxattrlen.3
+++ b/man/genders_getmaxattrlen.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_getmaxattrs.3
+++ b/man/genders_getmaxattrs.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_getmaxnodelen.3
+++ b/man/genders_getmaxnodelen.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_getmaxvallen.3
+++ b/man/genders_getmaxvallen.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_getnodename.3
+++ b/man/genders_getnodename.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -42,14 +42,14 @@ hostname of the node.
 To avoid passing in a buffer that is not large enough to store the
 node name,
 .BR genders_getmaxnodelen (3)
-should be used to determine the minimum buffer size that should be used. 
+should be used to determine the minimum buffer size that should be used.
 .br
 .SH RETURN VALUES
 On success, 0 is returned.  On error, -1 is returned, and an error
 code is returned in \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -67,9 +67,9 @@ has not been called to load genders data.
 The buffer pointed to by \fInode\fR is not large enough to store the node name.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_getnodes.3
+++ b/man/genders_getnodes.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -45,7 +45,7 @@ nodes,
 .BR genders_getnumnodes (3)
 should be used to determine the minimum number of elements \fInodes\fR
 should be able to store.
-.BR genders_nodelist_create (3) 
+.BR genders_nodelist_create (3)
 could be used to create a list that is guaranteed to be large enough
 to store all of the nodes.
 .br
@@ -54,8 +54,8 @@ On success, the number of nodes stored in \fInodes\fR is returned.  On
 error, -1 is returned, and an error code is returned in \fIhandle\fR.
 The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -74,12 +74,12 @@ The list pointed to by \fInodes\fR is not large enough to store all
 the nodes.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_NULLPTR
 A null pointer has been found in the list passed in.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_getnumattrs.3
+++ b/man/genders_getnumattrs.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_getnumnodes.3
+++ b/man/genders_getnumnodes.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -77,8 +77,8 @@ memory to store genders file information in.
 On success, 0 is returned.  On error, -1 is returned, and an error
 code is returned in \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -92,7 +92,7 @@ created with
 .BR genders_load_data (3)
 has not been called to load genders data.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_handle_create.3
+++ b/man/genders_handle_create.3
@@ -6,26 +6,26 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
 .TH GENDERS_HANDLE_CREATE 3 "August 2003" "LLNL" "LIBGENDERS"
 .SH NAME
-genders_handle_create \- create a genders handle 
+genders_handle_create \- create a genders handle
 .SH SYNOPSIS
 .B #include <genders.h>
 .sp

--- a/man/genders_handle_destroy.3
+++ b/man/genders_handle_destroy.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -39,8 +39,8 @@ by \fIhandle\fR and frees all allocated memory associated with it.
 On success, 0 is returned.  On error, -1 is returned, and an error
 code is returned in \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -50,7 +50,7 @@ The \fIhandle\fR parameter is NULL.  The genders handle must be
 created with
 .BR genders_handle_create (3).
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has already been destroyed.
 .br

--- a/man/genders_index_attrvals.3
+++ b/man/genders_index_attrvals.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -50,8 +50,8 @@ overwrite earlier indexes.
 On success, 0 is returned.  On error, -1 is returned, and an error
 code is returned in \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -66,7 +66,7 @@ created with
 has not been called to load genders data.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_NOTFOUND
 The attribute pointed to by \fIattr\fR cannot be found in the genders
@@ -76,13 +76,13 @@ file.
 .BR malloc (3)
 has failed internally, system is out of memory.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).
 .TP
 .B GENDERS_ERR_INTERNAL
-An internal system error has occurred.  
+An internal system error has occurred.
 .br
 .SH FILES
 /usr/include/genders.h

--- a/man/genders_isattr.3
+++ b/man/genders_isattr.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_isattrval.3
+++ b/man/genders_isattrval.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_isnode.3
+++ b/man/genders_isnode.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -60,8 +60,8 @@ the genders file, 1 is returned.  If it is not listed, 0 is returned.
 On error, all three return -1 and an error code is returned in
 \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -76,9 +76,9 @@ created with
 has not been called to load genders data.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_load_data.3
+++ b/man/genders_load_data.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -37,7 +37,7 @@ by \fIfilename\fR.  If \fIfilename\fR is NULL,
 \fBgenders_load_data()\fR will attempt to read and parse the default
 genders file defined by \fBGENDERS_DEFAULT_FILE\fR. \fIhandle\fR is a
 genders handle created by
-.BR genders_handle_create (3).  
+.BR genders_handle_create (3).
 
 After \fBgenders_load_data()\fR is called, information about the
 genders file is stored in the genders handle passed in.  This
@@ -50,8 +50,8 @@ default genders file if \fIfilename\fR is NULL).
 On success, 0 is returned.  On error, -1 is returned, and an error
 code is returned in \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -71,8 +71,8 @@ Error reading the genders file indicated by \fIfilename\fR.
 The genders file indicated by \fIfilename\fR is incorrectly formatted.
 .TP
 .B GENDERS_ERR_ISLOADED
-.BR genders_load_data (3) 
-has already been called with \fIhandle\fR.  
+.BR genders_load_data (3)
+has already been called with \fIhandle\fR.
 .TP
 .B GENDERS_ERR_OVERFLOW
 A line in the genders database exceeds the maximum allowed length.
@@ -81,13 +81,13 @@ A line in the genders database exceeds the maximum allowed length.
 .BR malloc (3)
 has failed internally, system is out of memory.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).
 .TP
 .B GENDERS_ERR_INTERNAL
-An internal system error has occurred.  
+An internal system error has occurred.
 .br
 .SH FILES
 /usr/include/genders.h

--- a/man/genders_nodelist_clear.3
+++ b/man/genders_nodelist_clear.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_nodelist_create.3
+++ b/man/genders_nodelist_create.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -61,7 +61,7 @@ lists (arrays of strings) for use with
 .BR genders_getnodes (3),
 .BR genders_getattr (3),
 and
-.BR genders_getattr_all (3).  
+.BR genders_getattr_all (3).
 
 \fBgenders_nodelist_create()\fR, \fBgenders_attrlist_create()\fR, and
 \fBgenders_vallist_create()\fR creates a list with minimum size to
@@ -72,7 +72,7 @@ store all the node, attribute, and value information returned from
 .BR genders_getnodes (3),
 .BR genders_getattr (3),
 and
-.BR genders_getattr_all (3).  
+.BR genders_getattr_all (3).
 
 \fBgenders_nodelist_clear()\fR, \fBgenders_attrlist_clear()\fR, and
 \fBgenders_vallist_clear()\fR clear any information stored in the
@@ -83,7 +83,7 @@ functions.  They only have to be called after they are used in
 .BR genders_getattr (3),
 and
 .BR genders_getattr_all (3),
-and the programmer wishes to re-use the list.  
+and the programmer wishes to re-use the list.
 
 \fBgenders_nodelist_destroy()\fR, \fBgenders_attrlist_destroy()\fR,
 and \fBgenders_vallist_destroy()\fR destroy the lists pointed to by
@@ -105,8 +105,8 @@ return the number of elements the created list can store.  On success,
 return 0.  On error, -1 is returned, and an error code is returned in
 \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -122,7 +122,7 @@ has not been called to load genders data.  Before lists of appropriate
 size can be created, the genders file must be read and parsed.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_NULLPTR
 A null pointer has been found in the list passed in.
@@ -131,7 +131,7 @@ A null pointer has been found in the list passed in.
 .BR malloc (3)
 has failed internally, system is out of memory.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_nodelist_destroy.3
+++ b/man/genders_nodelist_destroy.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_parse.3
+++ b/man/genders_parse.3
@@ -6,27 +6,27 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
 .TH GENDERS_PARSE 3 "August 2003" "LLNL" "LIBGENDERS"
 .SH NAME
 genders_parse \- determine errors with a genders file
-.SH SYNOPSIS 
+.SH SYNOPSIS
 .B #include <genders.h>
 .sp
 .BI "int genders_parse(genders_t handle, const char *filename, FILE *stream);"
@@ -44,8 +44,8 @@ there are no errors, 0 is returned.  On error, -1 is returned, and an
 error code is returned in \fIhandle\fR.  The error code can be
 retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -61,7 +61,7 @@ The genders file indicated by \fIfilename\fR cannot be opened for reading.
 .B GENDERS_ERR_OVERFLOW
 A line in the genders database exceeds the maximum allowed length.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_perror.3
+++ b/man/genders_perror.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_query.3
+++ b/man/genders_query.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -96,7 +96,7 @@ The list pointed to by \fInodes\fR is not large enough to store all
 the nodes.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_SYNTAX
 There is a syntax error in the query.
@@ -108,13 +108,13 @@ has failed internally, system is out of memory.
 .B GENDERS_ERR_NULLPTR
 A null pointer has been found in the list passed in.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).
 .TP
 .B GENDERS_ERR_INTERNAL
-An internal system error has occurred.  
+An internal system error has occurred.
 .br
 .SH FILES
 /usr/include/genders.h

--- a/man/genders_strerror.3
+++ b/man/genders_strerror.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_testattr.3
+++ b/man/genders_testattr.3
@@ -6,26 +6,26 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
 .TH GENDERS_TESTATTR 3 "August 2003" "LLNL" "LIBGENDERS"
 .SH NAME
-genders_testattr \- test if a node has an attribute  
+genders_testattr \- test if a node has an attribute
 .SH SYNOPSIS
 .B #include <genders.h>
 .sp
@@ -64,8 +64,8 @@ For both \fBgenders_testattr()\fR and \fBgenders_testattrval()\fR, -1
 is returned on error, and an error code is returned in \fIhandle\fR.
 The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -84,14 +84,14 @@ The buffer pointed to by \fIval\fR is not large enough to store the
 attribute value.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_NOTFOUND
 The node pointed to by \fInode\fR cannot be found in the genders file
 or if \fInode\fR=NULL, the machine genders is running on is not listed
 in the genders database.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_testattrval.3
+++ b/man/genders_testattrval.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_testquery.3
+++ b/man/genders_testquery.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -81,7 +81,7 @@ created with
 has not been called to load genders data.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_SYNTAX
 There is a syntax error in the query.
@@ -90,13 +90,13 @@ There is a syntax error in the query.
 .BR malloc (3)
 has failed internally, system is out of memory.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).
 .TP
 .B GENDERS_ERR_INTERNAL
-An internal system error has occurred.  
+An internal system error has occurred.
 .br
 .SH FILES
 /usr/include/genders.h

--- a/man/genders_vallist_clear.3
+++ b/man/genders_vallist_clear.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_vallist_create.3
+++ b/man/genders_vallist_create.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/genders_vallist_destroy.3
+++ b/man/genders_vallist_destroy.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################

--- a/man/libgenders.3
+++ b/man/libgenders.3
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -133,7 +133,7 @@ Here is an example genders file from a small 16-node linux cluster:
 
      # slc cluster genders file
      slci,slcj,slc[0-15]  eth2=e%n,cluster=slc,all
-     slci                 passwdhost                 
+     slci                 passwdhost
      slci,slcj            management
      slc[1-15]            compute
 

--- a/man/nodeattr.1
+++ b/man/nodeattr.1
@@ -6,20 +6,20 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Genders, a cluster configuration database.
 .\"  For details, see <http://www.llnl.gov/linux/genders/>.
-.\"  
+.\"
 .\"  Genders is free software; you can redistribute it and/or modify it under
 .\"  the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 .\"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 .\"  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 .\"  details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 .\"############################################################################
@@ -65,13 +65,13 @@ nodeattr \- query genders file
 .I "[-f genders] --compress-hosts"
 .br
 .SH DESCRIPTION
-When invoked with the 
+When invoked with the
 .I "-q"
 ,
 .I "-c"
 ,
 .I "-n"
-, or 
+, or
 .I "-s"
 arguments,
 .B nodeattr
@@ -87,7 +87,7 @@ symbols ('||'), intersection by two ampersand symbols ('&&'), difference by two
 minus symbols ('--'), and
 complement by a tilde ('~').  Parentheses may be used to change the order of
 operations.
-The 
+The
 .I "-X"
 argument and query can be used to exclude nodes from the resulting
 output.  A query can be replaced with the
@@ -121,13 +121,13 @@ option causes
 to print all of the values that exist for a particular attribute.
 Also specifying
 .I "-U"
-with 
+with
 .I "-V"
-causes 
+causes
 .B nodeattr
 to print out only unique values for the particular attribute.
 .LP
-The 
+The
 .I "-l"
 option causes
 .B nodeattr
@@ -140,11 +140,11 @@ option checks the genders file for parse errors and proper formatting.
 If errors are found, information about the error will be output to
 standard error.
 .LP
-.B Nodeattr 
+.B Nodeattr
 will always check the default genders file, but a different genders
 file can be specified with the
 .I "-f"
-option.  
+option.
 .LP
 The
 .I "-d"
@@ -156,14 +156,14 @@ the specified database will be output to standard error.
 Attribute names may optionally appear in the genders file with an
 equal sign followed by a value.
 .B Nodeattr
-ignores these values except when the 
-.I -v 
+ignores these values except when the
+.I -v
 option requests that the value, if any, be displayed; and when an
 attribute is specified on the command line with a value, in which case
 only an attribute with the specified value in the genders file will
 match.
 .LP
-For 
+For
 .I "--expand"
 .I "--compress"
 .I "--compress-attrs"

--- a/src/extensions/cplusplus/gendersplusplus.cpp
+++ b/src/extensions/cplusplus/gendersplusplus.cpp
@@ -103,7 +103,7 @@ void Genders::_constructor(const string filename)
 {
   if (!(gh = genders_handle_create()))
     _throw_exception(GENDERS_ERR_OUTMEM);
-  
+
   if (genders_load_data(gh, filename.c_str()) < 0)
     {
       int errnum = genders_errnum(gh);
@@ -218,10 +218,10 @@ vector< string > Genders::getnodes(const string attr, const string val) const
       genders_nodelist_destroy(gh, nodelist);
       _throw_exception(errnum);
     }
-  
+
   for (int i = 0; i < nodelist_count; i++)
     rv.push_back(nodelist[i]);
-  
+
   genders_nodelist_destroy(gh, nodelist);
   return rv;
 }
@@ -283,7 +283,7 @@ vector< string > Genders::getattr_all() const
       genders_attrlist_destroy(gh, attrlist);
       _throw_exception(errnum);
     }
-  
+
   for (int i = 0; i < attrlist_count; i++)
     rv.push_back(attrlist[i]);
 
@@ -297,10 +297,10 @@ bool Genders::testattr(const string attr, string &val, const string node) const
   int maxvallen;
   int ret;
   bool rv = false;
-  
+
   if ((maxvallen = genders_getmaxvallen(gh)) < 0)
     _throw_exception(genders_errnum(gh));
-  
+
   if (!(valbuf = (char *)malloc(maxvallen + 1)))
     _throw_exception(genders_errnum(gh));
 
@@ -338,7 +338,7 @@ bool Genders::testattrval(const string attr, const string val, const string node
 				 attr.c_str(),
 				 val.c_str())) < 0)
     _throw_exception(genders_errnum(gh));
-  
+
   if (ret)
     rv = true;
 
@@ -406,10 +406,10 @@ vector< string > Genders::query(const string query) const
       genders_nodelist_destroy(gh, nodelist);
       _throw_exception(errnum);
     }
-  
+
   for (int i = 0; i < nodelist_count; i++)
     rv.push_back(nodelist[i]);
-  
+
   genders_nodelist_destroy(gh, nodelist);
   return rv;
 }

--- a/src/extensions/java/src/Gendersjni.c
+++ b/src/extensions/java/src/Gendersjni.c
@@ -114,7 +114,7 @@ Java_gov_llnl_lc_chaos_Genders_genders_1constructor (JNIEnv *env, jobject obj, j
     {
       if (!(filenameutf = (*env)->GetStringUTFChars(env, filename, NULL)))
 	goto cleanup;
-      
+
       rv = _constructor (env, obj, filenameutf);
 
     }
@@ -139,7 +139,7 @@ _get_handle (JNIEnv *env, jobject obj, genders_t *handle)
 
   if (!(gh_addr_fid = (*env)->GetFieldID (env, genders_cls, "gh_addr", "J")))
     goto cleanup;
-  
+
   jgh_addr_addr = (*env)->GetLongField (env, obj, gh_addr_fid);
 
   if (!jgh_addr_addr)
@@ -288,7 +288,7 @@ _getnodes (JNIEnv *env, jobject obj, const char *attr, const char *val)
   for (i = 0; i < nodeslen; i++)
     {
       jstring tmpstr;
-      
+
       if (!(tmpstr = (*env)->NewStringUTF(env, nodelist[i])))
 	goto cleanup;
 
@@ -400,7 +400,7 @@ _getattr (JNIEnv *env, jobject obj, const char *node)
   for (i = 0; i < attrslen; i++)
     {
       jstring tmpstr;
-      
+
       if (!(tmpstr = (*env)->NewStringUTF(env, attrlist[i])))
 	goto cleanup;
 
@@ -478,7 +478,7 @@ Java_gov_llnl_lc_chaos_Genders_getattr_1all (JNIEnv *env, jobject obj)
   for (i = 0; i < attrslen; i++)
     {
       jstring tmpstr;
-      
+
       if (!(tmpstr = (*env)->NewStringUTF(env, attrlist[i])))
 	goto cleanup;
 
@@ -532,7 +532,7 @@ _getattrval (JNIEnv *env, jobject obj, const char *node, const char *attr)
       if (!(jval = (*env)->NewStringUTF(env, valbuf)))
 	goto cleanup;
     }
-  
+
   rv = jval;
  cleanup:
   free (valbuf);
@@ -907,7 +907,7 @@ Java_gov_llnl_lc_chaos_Genders_query (JNIEnv *env, jobject obj, jstring query)
   for (i = 0; i < nodeslen; i++)
     {
       jstring tmpstr;
-      
+
       if (!(tmpstr = (*env)->NewStringUTF(env, nodelist[i])))
 	goto cleanup;
 

--- a/src/extensions/perl/Genders/Genders.pm.in
+++ b/src/extensions/perl/Genders/Genders.pm.in
@@ -6,20 +6,20 @@
 #  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 #  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 #  UCRL-CODE-2003-004.
-#  
+#
 #  This file is part of Genders, a cluster configuration database.
 #  For details, see <http://www.llnl.gov/linux/genders/>.
-#  
+#
 #  Genders is free software; you can redistribute it and/or modify it under
 #  the terms of the GNU General Public License as published by the Free
 #  Software Foundation; either version 2 of the License, or (at your option)
 #  any later version.
-#  
+#
 #  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 #  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 #  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 #  details.
-#  
+#
 #  You should have received a copy of the GNU General Public License along
 #  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
@@ -34,9 +34,9 @@ our $VERSION = "@PERLGENDERS_VERSION@";
 require Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(&_errormsg $GENDERS_DEFAULT_FILE $debugkey $handlekey);
-our %EXPORT_TAGS = ( 'all' => [ qw(&_errormsg 
-                                   $GENDERS_DEFAULT_FILE 
-                                   $debugkey 
+our %EXPORT_TAGS = ( 'all' => [ qw(&_errormsg
+                                   $GENDERS_DEFAULT_FILE
+                                   $debugkey
                                    $handlekey) ] );
 
 our $GENDERS_DEFAULT_FILE = Libgenders->GENDERS_DEFAULT_FILE;
@@ -61,9 +61,9 @@ sub new {
     my $self = {};
     my $handle;
     my $rv;
-    
+
     $self->{$debugkey} = 0;
-    
+
     $handle = Libgenders->genders_handle_create();
     if (!defined($handle)) {
         _errormsg($self, "genders_handle_create()");
@@ -76,7 +76,7 @@ sub new {
     if ($rv < 0) {
         _errormsg($self, "genders_load_data()");
         return undef;
-    } 
+    }
 
     bless ($self, $class);
     return $self;
@@ -197,7 +197,7 @@ sub testattr {
             _errormsg($self, "genders_testattr()");
             return 0;
         }
-        return $rv; 
+        return $rv;
     }
     else {
         return 0;
@@ -217,7 +217,7 @@ sub testattrval {
             _errormsg($self, "genders_testattrval()");
             return 0;
         }
-        return $rv; 
+        return $rv;
     }
     else {
         return 0;
@@ -235,7 +235,7 @@ sub isnode {
             _errormsg($self, "genders_isnode()");
             return 0;
         }
-        return $rv; 
+        return $rv;
     }
     else {
         return 0;
@@ -318,7 +318,7 @@ sub testquery {
             _errormsg($self, "genders_testquery()");
             return 0;
         }
-        return $rv; 
+        return $rv;
     }
     else {
         return 0;
@@ -458,7 +458,7 @@ Returns 1 if the specified node meets the conditions of the specified
 query, 0 if it does not.  If the node is not specified, the local node
 is checked.
 
-=back 
+=back
 
 =head1 AUTHOR
 

--- a/src/extensions/perl/Libgenders/Libgenders.pm.in
+++ b/src/extensions/perl/Libgenders/Libgenders.pm.in
@@ -6,20 +6,20 @@
 #  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 #  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 #  UCRL-CODE-2003-004.
-#  
+#
 #  This file is part of Genders, a cluster configuration database.
 #  For details, see <http://www.llnl.gov/linux/genders/>.
-#  
+#
 #  Genders is free software; you can redistribute it and/or modify it under
 #  the terms of the GNU General Public License as published by the Free
 #  Software Foundation; either version 2 of the License, or (at your option)
 #  any later version.
-#  
+#
 #  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
 #  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 #  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 #  details.
-#  
+#
 #  You should have received a copy of the GNU General Public License along
 #  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
@@ -98,7 +98,7 @@ Libgenders - Perl extension for libgenders
 
  $handle->genders_query([$query])
  $handle->genders_testquery($query, [$node])
- 
+
  $handle->genders_parse([$filename]);
 
 =head1 DESCRIPTION
@@ -142,7 +142,7 @@ Returns the error code most recently set.
 
 =item B<$handle-E<gt>genders_strerror($errnum)>
 
-Returns a string describing the error code $errnum.  
+Returns a string describing the error code $errnum.
 
 =item B<$handle-E<gt>genders_errormsg()>
 
@@ -275,7 +275,7 @@ success, -1 on error.
 =head2 Error Codes/Constants
 
 The same error codes and constants listed in /usr/include/genders.h
-can be accessed through the following functions: 
+can be accessed through the following functions:
 
  Libgenders::GENDERS_ERR_SUCCESS
  Libgenders::GENDERS_ERR_NULLHANDLE

--- a/src/extensions/perl/Libgenders/Libgenders.xs
+++ b/src/extensions/perl/Libgenders/Libgenders.xs
@@ -38,149 +38,149 @@
 
 #include <genders.h>
 
-MODULE = Libgenders             PACKAGE = Libgenders            
+MODULE = Libgenders             PACKAGE = Libgenders
 
 PROTOTYPES: ENABLE
 
 int
 GENDERS_ERR_SUCCESS (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_SUCCESS;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_NULLHANDLE (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_NULLHANDLE;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_OPEN (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_OPEN;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_READ (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_READ;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_PARSE (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_PARSE;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_NOTLOADED (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_NOTLOADED;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_ISLOADED (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_ISLOADED;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_OVERFLOW (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_OVERFLOW;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_PARAMETERS (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_PARAMETERS;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_NULLPTR (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_NULLPTR;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_NOTFOUND (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_NOTFOUND;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_OUTMEM (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_OUTMEM;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_SYNTAX (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_SYNTAX;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_MAGIC (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_MAGIC;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_INTERNAL (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_INTERNAL;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 GENDERS_ERR_ERRNUMRANGE (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_ERR_ERRNUMRANGE;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
-char * 
+char *
 GENDERS_DEFAULT_FILE (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = GENDERS_DEFAULT_FILE;
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 void
 DESTROY(handle)
-    genders_t handle    
+    genders_t handle
     CODE:
        (void)genders_handle_destroy(handle);
 
@@ -211,7 +211,7 @@ genders_errnum(handle)
 
 char *
 genders_strerror(handle, errnum)
-    genders_t handle    
+    genders_t handle
     int errnum
     CODE:
         RETVAL = genders_strerror(errnum);
@@ -250,21 +250,21 @@ genders_getnumattrs(handle)
         RETVAL
 
 SV *
-genders_getnodename(handle) 
+genders_getnodename(handle)
     genders_t handle
     PREINIT:
         int len;
         char *buf = NULL;
     CODE:
-        if ((len = genders_getmaxnodelen(handle)) < 0) 
+        if ((len = genders_getmaxnodelen(handle)) < 0)
             goto handle_error;
 
-        if (!(buf = (char *)malloc(len+1))) 
+        if (!(buf = (char *)malloc(len+1)))
             goto handle_error;
 
         memset(buf, '\0', len+1);
 
-        if (genders_getnodename(handle, buf, len+1) < 0) 
+        if (genders_getnodename(handle, buf, len+1) < 0)
             goto handle_error;
 
         RETVAL = newSVpv(buf, 0);
@@ -281,15 +281,15 @@ genders_getnodename(handle)
         RETVAL
 
 AV *
-genders_getnodes(handle, attr=NULL, val=NULL) 
+genders_getnodes(handle, attr=NULL, val=NULL)
     genders_t handle
     char *attr
     char *val
     PREINIT:
         int len, num, errnum, i;
-        char **nlist = NULL; 
+        char **nlist = NULL;
     CODE:
-        if ((len = genders_nodelist_create(handle, &nlist)) < 0) 
+        if ((len = genders_nodelist_create(handle, &nlist)) < 0)
             goto handle_error;
 
         if ((num = genders_getnodes(handle, nlist, len, attr, val)) < 0)
@@ -298,7 +298,7 @@ genders_getnodes(handle, attr=NULL, val=NULL)
         RETVAL = newAV();
         for (i = 0; i < num; i++)
             av_push(RETVAL, newSVpv(nlist[i], 0));
-        
+
         if (genders_nodelist_destroy(handle, nlist) < 0)
             goto handle_error;
 
@@ -316,7 +316,7 @@ genders_getnodes(handle, attr=NULL, val=NULL)
 
         the_end:
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 AV *
 genders_getattr(handle, node=NULL)
@@ -324,15 +324,15 @@ genders_getattr(handle, node=NULL)
     char *node
     PREINIT:
         int len, num, errnum, i;
-        char **alist = NULL; 
-        char **vlist = NULL; 
+        char **alist = NULL;
+        char **vlist = NULL;
         AV *attrs;
         AV *vals;
     CODE:
-        if ((len = genders_attrlist_create(handle, &alist)) < 0) 
+        if ((len = genders_attrlist_create(handle, &alist)) < 0)
             goto handle_error;
 
-        if ((len = genders_vallist_create(handle, &vlist)) < 0) 
+        if ((len = genders_vallist_create(handle, &vlist)) < 0)
             goto handle_error;
 
         if ((num = genders_getattr(handle, alist, vlist, len, node)) < 0)
@@ -345,11 +345,11 @@ genders_getattr(handle, node=NULL)
         vals = newAV();
         for (i = 0; i < num; i++)
             av_push(vals, newSVpv(vlist[i], 0));
-        
+
         RETVAL = newAV();
         av_push(RETVAL, newRV_noinc((SV *)attrs));
         av_push(RETVAL, newRV_noinc((SV *)vals));
-    
+
         if (genders_attrlist_destroy(handle, alist) < 0)
             goto handle_error;
 	alist = NULL;
@@ -368,7 +368,7 @@ genders_getattr(handle, node=NULL)
             (void)genders_vallist_destroy(handle, vlist);
 
             genders_set_errnum(handle, errnum);
-           
+
             XSRETURN_UNDEF;
 
         the_end:
@@ -380,9 +380,9 @@ genders_getattr_all(handle)
     genders_t handle
     PREINIT:
         int len, num, errnum, i;
-        char **alist = NULL; 
+        char **alist = NULL;
     CODE:
-        if ((len = genders_attrlist_create(handle, &alist)) < 0) 
+        if ((len = genders_attrlist_create(handle, &alist)) < 0)
             goto handle_error;
 
         if ((num = genders_getattr_all(handle, alist, len)) < 0)
@@ -391,16 +391,16 @@ genders_getattr_all(handle)
         RETVAL = newAV();
         for (i = 0; i < num; i++)
             av_push(RETVAL, newSVpv(alist[i], 0));
-        
+
         if (genders_attrlist_destroy(handle, alist) < 0)
             goto handle_error;
 
         goto the_end;
-                    
+
         handle_error:
 
             errnum = genders_errnum(handle);
-        
+
             (void)genders_attrlist_destroy(handle, alist);
 
             genders_set_errnum(handle, errnum);
@@ -409,7 +409,7 @@ genders_getattr_all(handle)
 
         the_end:
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 SV *
 genders_getattrval(handle, attr, node=NULL)
@@ -421,10 +421,10 @@ genders_getattrval(handle, attr, node=NULL)
         char *buf = NULL;
     CODE:
 
-        if ((len = genders_getmaxvallen(handle)) < 0) 
+        if ((len = genders_getmaxvallen(handle)) < 0)
             goto handle_error;
 
-        if (!(buf = (char *)malloc(len+1))) 
+        if (!(buf = (char *)malloc(len+1)))
             goto handle_error;
 
         memset(buf, '\0', len+1);
@@ -432,9 +432,9 @@ genders_getattrval(handle, attr, node=NULL)
         if ((rv = genders_testattr(handle, node, attr, buf, len+1)) < 0)
             goto handle_error;
 
-        if (rv == 1 && strlen(buf) > 0) 
+        if (rv == 1 && strlen(buf) > 0)
             RETVAL = newSVpv(buf, 0);
-        else 
+        else
             RETVAL = newSVpv("", 0);
 
         free(buf);
@@ -444,7 +444,7 @@ genders_getattrval(handle, attr, node=NULL)
 
             free(buf);
             XSRETURN_UNDEF;
-        
+
         the_end:
     OUTPUT:
         RETVAL
@@ -457,7 +457,7 @@ genders_testattr(handle, attr, node=NULL)
     CODE:
         RETVAL = genders_testattrval(handle, node, attr, NULL);
     OUTPUT:
-        RETVAL      
+        RETVAL
 
 int
 genders_testattrval(handle, attr, val, node=NULL)
@@ -468,7 +468,7 @@ genders_testattrval(handle, attr, val, node=NULL)
     CODE:
         RETVAL = genders_testattrval(handle, node, attr, val);
     OUTPUT:
-        RETVAL      
+        RETVAL
 
 int
 genders_isnode(handle, node=NULL)
@@ -498,14 +498,14 @@ genders_isattrval(handle, attr, val)
     OUTPUT:
         RETVAL
 
-int 
+int
 genders_index_attrvals(handle, attr)
     genders_t handle
     char *attr
     CODE:
         RETVAL = genders_index_attrvals(handle, attr);
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 AV *
 genders_query(handle, query=NULL)
@@ -513,9 +513,9 @@ genders_query(handle, query=NULL)
     char *query
     PREINIT:
         int len, num, errnum, i;
-        char **nlist = NULL; 
+        char **nlist = NULL;
     CODE:
-        if ((len = genders_nodelist_create(handle, &nlist)) < 0) 
+        if ((len = genders_nodelist_create(handle, &nlist)) < 0)
             goto handle_error;
 
         if ((num = genders_query(handle, nlist, len, query)) < 0)
@@ -524,7 +524,7 @@ genders_query(handle, query=NULL)
         RETVAL = newAV();
         for (i = 0; i < num; i++)
             av_push(RETVAL, newSVpv(nlist[i], 0));
-        
+
         if (genders_nodelist_destroy(handle, nlist) < 0)
             goto handle_error;
 
@@ -542,7 +542,7 @@ genders_query(handle, query=NULL)
 
         the_end:
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 int
 genders_testquery(handle, query, node=NULL)
@@ -552,7 +552,7 @@ genders_testquery(handle, query, node=NULL)
     CODE:
         RETVAL = genders_testquery(handle, node, query);
     OUTPUT:
-        RETVAL      
+        RETVAL
 
 int
 genders_parse(handle, filename=NULL)

--- a/src/extensions/python/libgendersmodule.c
+++ b/src/extensions/python/libgendersmodule.c
@@ -127,12 +127,12 @@ Libgenders_load_data(Libgenders *self, PyObject *args)
     _genders_exception_check(self);
     goto cleanup;
   }
-  
+
   if (!(rv = Py_BuildValue("i", ret)))
     goto cleanup;
-  
+
  cleanup:
-  return rv; 
+  return rv;
 }
 
 static PyObject *
@@ -254,7 +254,7 @@ _build_comma_separated_string(int maxitemlen, char **itemlist, int itemlistlen)
 
   if (!(rv = Py_BuildValue("s", stringbuf)))
     goto cleanup;
-  
+
  cleanup:
   free(stringbuf);
   return rv;
@@ -301,12 +301,12 @@ Libgenders_getnodes(Libgenders *self, PyObject *args)
     if (!(rv = Py_BuildValue("z", NULL)))
       goto cleanup;
   }
-  
+
  cleanup:
   errnum = genders_errnum(self->gh);
   genders_nodelist_destroy(self->gh, nodelist);
   genders_set_errnum(self->gh, errnum);
-  return rv; 
+  return rv;
 }
 
 static PyObject *
@@ -353,12 +353,12 @@ Libgenders_getattr(Libgenders *self, PyObject *args)
     if (!(rv = Py_BuildValue("z", NULL)))
       goto cleanup;
   }
-  
+
  cleanup:
   errnum = genders_errnum(self->gh);
   genders_attrlist_destroy(self->gh, attrlist);
   genders_set_errnum(self->gh, errnum);
-  return rv; 
+  return rv;
 }
 
 static PyObject *
@@ -399,12 +399,12 @@ Libgenders_getattr_all(Libgenders *self)
     if (!(rv = Py_BuildValue("z", NULL)))
       goto cleanup;
   }
-  
+
  cleanup:
   errnum = genders_errnum(self->gh);
   genders_attrlist_destroy(self->gh, attrlist);
   genders_set_errnum(self->gh, errnum);
-  return rv; 
+  return rv;
 }
 
 static PyObject *
@@ -461,7 +461,7 @@ Libgenders_getattrval(Libgenders *self, PyObject *args)
     PyErr_NoMemory();
     goto cleanup;
   }
- 
+
   memset(valbuf, '\0', maxvallen + 1);
 
   if ((ret = genders_testattr(self->gh, node, attr, valbuf, maxvallen + 1)) < 0) {
@@ -477,10 +477,10 @@ Libgenders_getattrval(Libgenders *self, PyObject *args)
     if (!(rv = Py_BuildValue("z", NULL)))
       goto cleanup;
   }
-  
+
  cleanup:
   free(valbuf);
-  return rv; 
+  return rv;
 }
 
 static PyObject *
@@ -525,7 +525,7 @@ Libgenders_testattrval(Libgenders *self, PyObject *args)
 
   if (!(rv = Py_BuildValue("i", ret)))
     goto cleanup;
-  
+
  cleanup:
   return rv;
 }
@@ -644,7 +644,7 @@ Libgenders_query(Libgenders *self, PyObject *args)
 
   if (nodelen) {
     int maxnodelen;
-    
+
     if ((maxnodelen = genders_getmaxnodelen(self->gh)) < 0) {
       _genders_exception_check(self);
       goto cleanup;
@@ -659,12 +659,12 @@ Libgenders_query(Libgenders *self, PyObject *args)
     if (!(rv = Py_BuildValue("z", NULL)))
       goto cleanup;
   }
-  
+
  cleanup:
   errnum = genders_errnum(self->gh);
   genders_nodelist_destroy(self->gh, nodelist);
   genders_set_errnum(self->gh, errnum);
-  return rv; 
+  return rv;
 }
 
 static PyObject *
@@ -880,7 +880,7 @@ PyInit_libgenders(void)
 #endif
 
 PyMODINIT_FUNC
-initlibgenders(void) 
+initlibgenders(void)
 #endif
 {
   PyObject* m;

--- a/src/libcommon/hash.c
+++ b/src/libcommon/hash.c
@@ -29,7 +29,7 @@
  *  Copyright (C) 2003-2005 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Chris Dunlap <cdunlap@llnl.gov>.
- *  
+ *
  *  This file is from LSD-Tools, the LLNL Software Development Toolbox.
  *
  *  This is free software; you can redistribute it and/or modify it

--- a/src/libcommon/hash.h
+++ b/src/libcommon/hash.h
@@ -4,7 +4,7 @@
  *  Copyright (C) 2003-2005 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Chris Dunlap <cdunlap@llnl.gov>.
- *  
+ *
  *  This file is from LSD-Tools, the LLNL Software Development Toolbox.
  *
  *  This is free software; you can redistribute it and/or modify it

--- a/src/libcommon/hostlist.c
+++ b/src/libcommon/hostlist.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>
  *  UCRL-CODE-2002-040.
- *  
+ *
  *  This file is part of SLURM, a resource management program.
  *  For details, see <http://www.llnl.gov/linux/slurm/>.
- *  
+ *
  *  SLURM is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  SLURM is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with SLURM; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -87,7 +87,7 @@
         return(lsd_nomem_error(__FILE__, __LINE__, mesg));                   \
     } while (0)
 
-/* 
+/*
  * Some constants and tunables:
  */
 
@@ -317,7 +317,7 @@ static int hostset_find_host(hostset_t, const char *);
 #define UNLOCK_HOSTLIST(_hl)                                                 \
       do {                                                                   \
           mutex_unlock(&(_hl)->mutex);                                       \
-      } while (0)                       
+      } while (0)
 
 #define seterrno_ret(_errno, _rc)                                            \
       do {                                                                   \
@@ -341,7 +341,7 @@ static void _error(char *file, int line, char *msg, ...)
     va_start(ap, msg);
 
     len = vsnprintf(buf, 1024, msg, ap);
-    if ((len < 0) || (len > 1024)) 
+    if ((len < 0) || (len > 1024))
         buf[1023] = '\0';
 
     lsd_fatal_error(file, line, buf);
@@ -366,8 +366,8 @@ static int _advance_past_brackets (char *tok, char **str)
     return 0;
 }
 
-/* 
- * Helper function for host list string parsing routines 
+/*
+ * Helper function for host list string parsing routines
  * Returns a pointer to the next token; additionally advance *str
  * to the next separator.
  *
@@ -420,12 +420,12 @@ static int _zero_padded(unsigned long num, int width)
 }
 
 /* test whether two format `width' parameters are "equivalent"
- * The width arguments "wn" and "wm" for integers "n" and "m" 
+ * The width arguments "wn" and "wm" for integers "n" and "m"
  * are equivalent if:
- *  
+ *
  *  o  wn == wm  OR
  *
- *  o  applying the same format width (either wn or wm) to both of  
+ *  o  applying the same format width (either wn or wm) to both of
  *     'n' and 'm' will not change the zero padding of *either* 'm' nor 'n'.
  *
  *  If this function returns 1 (or true), the appropriate width value
@@ -467,19 +467,19 @@ static int _width_equiv(unsigned long n, int *wn, unsigned long m, int *wm)
 
 /* ----[ hostname_t functions ]---- */
 
-/* 
+/*
  * return the location of the last char in the hostname prefix
  */
 static int host_prefix_end(const char *hostname)
 {
     int idx = strlen(hostname) - 1;
 
-    while (idx >= 0 && isdigit((char) hostname[idx])) 
+    while (idx >= 0 && isdigit((char) hostname[idx]))
         idx--;
     return idx;
 }
 
-/* 
+/*
  * create a hostname_t object from a string hostname
  */
 static hostname_t hostname_create(const char *hostname)
@@ -547,7 +547,7 @@ static void hostname_destroy(hostname_t hn)
     free(hn);
 }
 
-/* return true if the hostname has a valid numeric suffix 
+/* return true if the hostname has a valid numeric suffix
  */
 static int hostname_suffix_is_valid(hostname_t hn)
 {
@@ -565,12 +565,12 @@ static int hostname_suffix_width(hostname_t hn)
 
 /* ----[ hostrange_t functions ]---- */
 
-/* allocate a new hostrange object 
+/* allocate a new hostrange object
  */
 static hostrange_t hostrange_new(void)
 {
     hostrange_t new = (hostrange_t) malloc(sizeof(*new));
-    if (!new) 
+    if (!new)
         out_of_memory("hostrange create");
     return new;
 }
@@ -700,7 +700,7 @@ static hostrange_t hostrange_delete_host(hostrange_t hr, unsigned long n)
 /* hostrange_cmp() is used to sort hostrange objects. It will
  * sort based on the following (in order):
  *  o result of strcmp on prefixes
- *  o if widths are compatible, then: 
+ *  o if widths are compatible, then:
  *       sort based on lowest suffix in range
  *    else
  *       sort based on width                     */
@@ -719,11 +719,11 @@ static int hostrange_cmp(hostrange_t h1, hostrange_t h2)
 }
 
 
-/* compare the prefixes of two hostrange objects. 
+/* compare the prefixes of two hostrange objects.
  * returns:
  *    < 0   if h1 prefix is less than h2 OR h1 == NULL.
  *
- *      0   if h1's prefix and h2's prefix match, 
+ *      0   if h1's prefix and h2's prefix match,
  *          UNLESS, either h1 or h2 (NOT both) do not have a valid suffix.
  *
  *    > 0   if h1's prefix is greater than h2's OR h2 == NULL. */
@@ -757,7 +757,7 @@ static int hostrange_within_range(hostrange_t h1, hostrange_t h2)
 }
 
 
-/* compare two hostrange objects to determine if they are width 
+/* compare two hostrange objects to determine if they are width
  * compatible,  returns:
  *  1 if widths can safely be combined
  *  0 if widths cannot be safely combined
@@ -795,10 +795,10 @@ static char *hostrange_pop(hostrange_t hr)
         hr->lo++;    /* effectively set count == 0 */
         host = strdup(hr->prefix);
     } else if (hostrange_count(hr) > 0) {
-        size = strlen(hr->prefix) + hr->width + 16;    
+        size = strlen(hr->prefix) + hr->width + 16;
         if (!(host = (char *) malloc(size * sizeof(char))))
             out_of_memory("hostrange pop");
-        snprintf(host, size, "%s%0*lu", hr->prefix, 
+        snprintf(host, size, "%s%0*lu", hr->prefix,
              hr->width, hr->hi--);
     }
 
@@ -835,7 +835,7 @@ static char *hostrange_shift(hostrange_t hr)
  *
  * -1 if ranges do not overlap (including incompatible zero padding)
  *  0 if ranges join perfectly
- * >0 number of hosts that were duplicated in  h1 and h2 
+ * >0 number of hosts that were duplicated in  h1 and h2
  *
  * h2 will be coalesced into h1 if rc >= 0
  *
@@ -889,7 +889,7 @@ static hostrange_t hostrange_intersect(hostrange_t h1, hostrange_t h2)
     assert(hostrange_cmp(h1, h2) <= 0);
 
     if ((hostrange_prefix_cmp(h1, h2) == 0)
-        && (h1->hi > h2->lo) 
+        && (h1->hi > h2->lo)
         && (hostrange_width_combine(h1, h2))) {
 
         if (!(new = hostrange_copy(h1)))
@@ -907,24 +907,24 @@ static hostrange_t hostrange_intersect(hostrange_t h1, hostrange_t h2)
 static int hostrange_hn_within(hostrange_t hr, hostname_t hn)
 {
     if (hr->singlehost) {
-        /*  
-         *  If the current hostrange [hr] is a `singlehost' (no valid 
+        /*
+         *  If the current hostrange [hr] is a `singlehost' (no valid
          *   numeric suffix (lo and hi)), then the hostrange [hr]
          *   stores just one host with name == hr->prefix.
-         *  
+         *
          *  Thus the full hostname in [hn] must match hr->prefix, in
-         *   which case we return true. Otherwise, there is no 
+         *   which case we return true. Otherwise, there is no
          *   possibility that [hn] matches [hr].
          */
         if (strcmp (hn->hostname, hr->prefix) == 0)
             return 1;
-        else 
+        else
             return 0;
     }
 
     /*
      *  Now we know [hr] is not a "singlehost", so hostname
-     *   better have a valid numeric suffix, or there is no 
+     *   better have a valid numeric suffix, or there is no
      *   way we can match
      */
     if (!hostname_suffix_is_valid (hn))
@@ -934,7 +934,7 @@ static int hostrange_hn_within(hostrange_t hr, hostname_t hn)
      *  If hostrange and hostname prefixes don't match, then
      *   there is way the hostname falls within the range [hr].
      */
-    if (strcmp(hr->prefix, hn->prefix) != 0) 
+    if (strcmp(hr->prefix, hn->prefix) != 0)
         return 0;
 
     /*
@@ -1007,7 +1007,7 @@ static size_t hostrange_numstr(hostrange_t hr, size_t n, char *buf)
 
     if ((len >= 0) && (len < n) && (hr->lo < hr->hi)) {
         int len2 = snprintf(buf+len, n-len, "-%0*lu", hr->width, hr->hi);
-        if (len2 < 0) 
+        if (len2 < 0)
             len = -1;
         else
             len += len2;
@@ -1019,7 +1019,7 @@ static size_t hostrange_numstr(hostrange_t hr, size_t n, char *buf)
 
 /* ----[ hostlist functions ]---- */
 
-/* Create a new hostlist object. 
+/* Create a new hostlist object.
  * Returns an empty hostlist, or NULL if memory allocation fails.
  */
 static hostlist_t hostlist_new(void)
@@ -1056,9 +1056,9 @@ static hostlist_t hostlist_new(void)
 /* Resize the internal array used to store the list of hostrange objects.
  *
  * returns 1 for a successful resize,
- *         0 if call to _realloc fails    
+ *         0 if call to _realloc fails
  *
- * It is assumed that the caller has the hostlist hl locked 
+ * It is assumed that the caller has the hostlist hl locked
  */
 static int hostlist_resize(hostlist_t hl, size_t newsize)
 {
@@ -1069,7 +1069,7 @@ static int hostlist_resize(hostlist_t hl, size_t newsize)
     oldsize = hl->size;
     hl->size = newsize;
     hl->hr = realloc((void *) hl->hr, hl->size*sizeof(hostrange_t));
-    if (!(hl->hr)) 
+    if (!(hl->hr))
         return 0;
 
     for (i = oldsize; i < newsize; i++)
@@ -1130,7 +1130,7 @@ static int hostlist_push_range(hostlist_t hl, hostrange_t hr)
 
 
 /* Same as hostlist_push_range() above, but prefix, lo, hi, and width
- * are passed as args 
+ * are passed as args
  */
 static int
 hostlist_push_hr(hostlist_t hl, char *prefix, unsigned long lo,
@@ -1242,23 +1242,23 @@ hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op)
 
         high = low = 0;
 
-        /* find end of alpha part 
+        /* find end of alpha part
          *   do this by finding last occurence of range_op in str */
         pos = strlen(tok) - 1;
         if (strstr(tok, r_op) != '\0') {
-            while (pos >= 0 && (char) tok[pos] != range_op) 
+            while (pos >= 0 && (char) tok[pos] != range_op)
                 pos--;
         }
 
         /* now back up past any digits */
         while (pos >= 0 && isdigit((char) tok[--pos])) {;}
 
-        /* Check for valid x-y range (x must be a digit) 
+        /* Check for valid x-y range (x must be a digit)
          *   Reset pos if the range is not valid         */
         if (!isdigit((char) tok[++pos]))
             pos = strlen(tok) - 1;
 
-        /* create prefix string 
+        /* create prefix string
          * if prefix will be zero length, but prefix already exists
          * use the previous prefix and fmt
          */
@@ -1317,7 +1317,7 @@ hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op)
             high = 0;    /* special case, ugh. */
         }
 
-        /* error if: 
+        /* error if:
          * 1. we are not at end of string
          * 2. upper bound equals lower bound
          */
@@ -1343,7 +1343,7 @@ hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op)
 
 #else                /* !WANT_RECKLESS_HOSTRANGE_EXPANSION */
 
-hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op) 
+hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op)
 {
     return _hostlist_create_bracketed(hostlist, sep, r_op);
 }
@@ -1355,7 +1355,7 @@ struct _range {
     int width;
 };
 
-/* Grab a single range from str 
+/* Grab a single range from str
  * returns 1 if str contained a valid number or range,
  *         0 if conversion of str to a range failed.
  */
@@ -1363,7 +1363,7 @@ static int _parse_single_range(const char *str, struct _range *range)
 {
     char *p, *q;
     char *orig = strdup(str);
-    if (!orig) 
+    if (!orig)
         seterrno_ret(ENOMEM, 0);
 
     if ((p = strchr(str, '-'))) {
@@ -1372,15 +1372,15 @@ static int _parse_single_range(const char *str, struct _range *range)
             goto error;
     }
     range->lo = strtoul(str, &q, 10);
-    if (q == str) 
+    if (q == str)
         goto error;
 
     range->hi = (p && *p) ? strtoul(p, &q, 10) : range->lo;
 
-    if (q == p || *q != '\0') 
+    if (q == p || *q != '\0')
         goto error;
 
-    if (range->lo > range->hi) 
+    if (range->lo > range->hi)
         goto error;
 
     if (range->hi - range->lo + 1 > MAX_RANGE ) {
@@ -1402,7 +1402,7 @@ static int _parse_single_range(const char *str, struct _range *range)
 
 /*
  * Convert 'str' containing comma separated digits and ranges into an array
- *  of struct _range types (max 'len' elements).  
+ *  of struct _range types (max 'len' elements).
  *
  * Return number of ranges created, or -1 on error.
  */
@@ -1416,8 +1416,8 @@ static int _parse_range_list(char *str, struct _range *ranges, int len)
             return -1;
         if ((p = strchr(str, ',')))
             *p++ = '\0';
-        if (!_parse_single_range(str, &ranges[count++])) 
-            return -1;  
+        if (!_parse_single_range(str, &ranges[count++]))
+            return -1;
         str = p;
     }
     return count;
@@ -1435,7 +1435,7 @@ _push_range_list(hostlist_t hl, char *pfx, struct _range *rng,
 }
 
 static void
-_push_range_list_with_suffix(hostlist_t hl, char *pfx, char *sfx, 
+_push_range_list_with_suffix(hostlist_t hl, char *pfx, char *sfx,
                              struct _range *rng, int n)
 {
     int i;
@@ -1457,10 +1457,10 @@ _push_range_list_with_suffix(hostlist_t hl, char *pfx, char *sfx,
 }
 
 /*
- * Create a hostlist from a string with brackets '[' ']' to aid 
+ * Create a hostlist from a string with brackets '[' ']' to aid
  * detection of ranges and compressed lists
  */
-static hostlist_t 
+static hostlist_t
 _hostlist_create_bracketed(const char *hostlist, char *sep, char *r_op)
 {
     hostlist_t new = hostlist_new();
@@ -1487,7 +1487,7 @@ _hostlist_create_bracketed(const char *hostlist, char *sep, char *r_op)
             if ((q = strchr(p, ']'))) {
                 *q = '\0';
                 nr = _parse_range_list(p, ranges, MAX_RANGES);
-                if (nr < 0) 
+                if (nr < 0)
                     goto error;
 
                 if (*(++q) != '\0')
@@ -1495,7 +1495,7 @@ _hostlist_create_bracketed(const char *hostlist, char *sep, char *r_op)
                 else
                     _push_range_list(new, prefix, ranges, nr);
 
-                
+
             } else
                 hostlist_push_host(new, cur_tok);
 
@@ -1645,7 +1645,7 @@ char *hostlist_pop(hostlist_t hl)
     return host;
 }
 
-/* find all iterators affected by a shift (or deletion) at 
+/* find all iterators affected by a shift (or deletion) at
  * hl->hr[idx], depth, with the deletion of n ranges */
 static void
 hostlist_shift_iterators(hostlist_t hl, int idx, int depth, int n)
@@ -1744,7 +1744,7 @@ char *hostlist_shift_range(hostlist_t hl)
     do {
         hostlist_push_range(hltmp, hl->hr[i]);
         hostrange_destroy(hl->hr[i]);
-    } while ( (++i < hl->nranges) 
+    } while ( (++i < hl->nranges)
             && hostrange_within_range(hltmp->hr[0], hl->hr[i]) );
 
     hostlist_shift_iterators(hl, i, 0, hltmp->nranges);
@@ -1802,7 +1802,7 @@ _hostrange_string(hostrange_t hr, int depth)
     int  len = snprintf(buf, MAXHOSTNAMELEN + 15, "%s", hr->prefix);
 
     if (!hr->singlehost)
-        snprintf(buf+len, MAXHOSTNAMELEN+15 - len, "%0*lu", 
+        snprintf(buf+len, MAXHOSTNAMELEN+15 - len, "%0*lu",
                  hr->width, hr->lo + depth);
     return strdup(buf);
 }
@@ -1905,7 +1905,7 @@ int hostlist_find(hostlist_t hl, const char *hostname)
     return ret;
 }
 
-/* hostrange compare with void * arguments to allow use with 
+/* hostrange compare with void * arguments to allow use with
  * libc qsort()
  */
 int _cmp(const void *hr1, const void *hr2)
@@ -1939,7 +1939,7 @@ void hostlist_sort(hostlist_t hl)
 }
 
 
-/* search through hostlist for ranges that can be collapsed 
+/* search through hostlist for ranges that can be collapsed
  * does =not= delete any hosts
  */
 static void hostlist_collapse(hostlist_t hl)
@@ -1961,7 +1961,7 @@ static void hostlist_collapse(hostlist_t hl)
     UNLOCK_HOSTLIST(hl);
 }
 
-/* search through hostlist (hl) for intersecting ranges 
+/* search through hostlist (hl) for intersecting ranges
  * split up duplicates and coalesce ranges where possible
  */
 static void hostlist_coalesce(hostlist_t hl)
@@ -2176,7 +2176,7 @@ ssize_t hostlist_ranged_string(hostlist_t hl, size_t n, char *buf)
 static hostlist_iterator_t hostlist_iterator_new(void)
 {
     hostlist_iterator_t i = (hostlist_iterator_t) malloc(sizeof(*i));
-    if (!i) 
+    if (!i)
         return NULL;
     i->hl = NULL;
     i->hr = NULL;
@@ -2295,7 +2295,7 @@ char *hostlist_next(hostlist_iterator_t i)
     len = strlen (i->hr->prefix) + strlen (suffix) + 1;
     if (!(buf = malloc (len)))
         out_of_memory("hostlist_next");
-    
+
     buf[0] = '\0';
     strcat (buf, i->hr->prefix);
     strcat (buf, suffix);
@@ -2396,9 +2396,9 @@ void hostset_destroy(hostset_t set)
     free(set);
 }
 
-/* inserts a single range object into a hostset 
+/* inserts a single range object into a hostset
  * Assumes that the set->hl lock is already held
- * Updates hl->nhosts 
+ * Updates hl->nhosts
  */
 static int hostset_insert_range(hostset_t set, hostrange_t hr)
 {
@@ -2418,7 +2418,7 @@ static int hostset_insert_range(hostset_t set, hostrange_t hr)
     for (i = 0; i < hl->nranges; i++) {
         if (hostrange_cmp(hr, hl->hr[i]) <= 0) {
 
-            if ((ndups = hostrange_join(hr, hl->hr[i])) >= 0) 
+            if ((ndups = hostrange_join(hr, hl->hr[i])) >= 0)
                 hostlist_delete_range(hl, i);
             else if (ndups < 0)
                 ndups = 0;
@@ -2444,10 +2444,10 @@ static int hostset_insert_range(hostset_t set, hostrange_t hr)
             if ((ndups = _attempt_range_join(hl, hl->nranges - 1)) <= 0)
                 ndups = 0;
         }
-    } 
+    }
 
-    /* 
-     *  Return the number of unique hosts inserted 
+    /*
+     *  Return the number of unique hosts inserted
      */
     return nhosts - ndups;
 }
@@ -2461,7 +2461,7 @@ int hostset_insert(hostset_t set, const char *hosts)
 
     hostlist_uniq(hl);
     LOCK_HOSTLIST(set->hl);
-    for (i = 0; i < hl->nranges; i++) 
+    for (i = 0; i < hl->nranges; i++)
         n += hostset_insert_range(set, hl->hr[i]);
     UNLOCK_HOSTLIST(set->hl);
     hostlist_destroy(hl);
@@ -2559,7 +2559,7 @@ ssize_t hostset_deranged_string(hostset_t set, size_t n, char *buf)
     return hostlist_deranged_string(set->hl, n, buf);
 }
 
-#if TEST_MAIN 
+#if TEST_MAIN
 
 int hostlist_nranges(hostlist_t hl)
 {
@@ -2710,6 +2710,6 @@ int main(int ac, char **av)
 
 #endif                /* TEST_MAIN */
 
-/* 
- * vi: tabstop=4 shiftwidth=4 expandtab 
+/*
+ * vi: tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/libcommon/hostlist.h
+++ b/src/libcommon/hostlist.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>
  *  UCRL-CODE-2002-040.
- *  
+ *
  *  This file is part of SLURM, a resource management program.
  *  For details, see <http://www.llnl.gov/linux/slurm/>.
- *  
+ *
  *  SLURM is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  SLURM is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with SLURM; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -38,7 +38,7 @@
  *    #define lsd_fatal_error(file,line,mesg)  \
  *              error("%s:%s %s\n",file,line,mesg);
  *
- * If WITH_LSD_NOMEM_ERROR_FUNC is defined, the linker will expect to 
+ * If WITH_LSD_NOMEM_ERROR_FUNC is defined, the linker will expect to
  * find an external lsd_nomem_error(file,line,mesg) function. By default,
  * lsd_nomem_error(file,line,mesg) is a macro definition that returns NULL.
  * This macro may be redefined to invoke another routine instead.
@@ -47,9 +47,9 @@
  *
  */
 
-/* The hostlist opaque data type 
+/* The hostlist opaque data type
  *
- * A hostlist is a list of hostnames optimized for a prefixXXXX style 
+ * A hostlist is a list of hostnames optimized for a prefixXXXX style
  * naming convention, where XXXX  is a decimal, numeric suffix.
  */
 typedef struct hostlist * hostlist_t;
@@ -57,7 +57,7 @@ typedef struct hostlist * hostlist_t;
 /* A hostset is a special case of a hostlist. It:
  *
  * 1. never contains duplicates
- * 2. is always sorted 
+ * 2. is always sorted
  *    (Note: sort occurs first on alphanumeric prefix -- where prefix
  *     matches, numeric suffixes will be sorted *by value*)
  */
@@ -65,7 +65,7 @@ typedef struct hostset * hostset_t;
 
 /* The hostlist iterator type (may be used with a hostset as well)
  * used for non-destructive access to hostlist members.
- * 
+ *
  */
 typedef struct hostlist_iterator * hostlist_iterator_t;
 
@@ -74,25 +74,25 @@ typedef struct hostlist_iterator * hostlist_iterator_t;
 /* ----[ hostlist creation and destruction ]---- */
 
 /*
- * hostlist_create(): 
+ * hostlist_create():
  *
- * Create a new hostlist from a string representation. 
+ * Create a new hostlist from a string representation.
  *
  * The string representation (str) may contain one or more hostnames or
- * bracketed hostlists separated by either `,' or whitespace. A bracketed 
- * hostlist is denoted by a common prefix followed by a list of numeric 
- * ranges contained within brackets: e.g. "tux[0-5,12,20-25]" 
+ * bracketed hostlists separated by either `,' or whitespace. A bracketed
+ * hostlist is denoted by a common prefix followed by a list of numeric
+ * ranges contained within brackets: e.g. "tux[0-5,12,20-25]"
  *
  * Note: if this module is compiled with WANT_RECKLESS_HOSTRANGE_EXPANSION
- * defined, a much more loose interpretation of host ranges is used. 
- * Reckless hostrange expansion allows all of the following (in addition to 
+ * defined, a much more loose interpretation of host ranges is used.
+ * Reckless hostrange expansion allows all of the following (in addition to
  * bracketed hostlists):
  *
  *  o tux0-5,tux12,tux20-25
  *  o tux0-tux5,tux12,tux20-tux25
  *  o tux0-5,12,20-25
  *
- * If str is NULL, and empty hostlist is created and returned. 
+ * If str is NULL, and empty hostlist is created and returned.
  *
  * If the create fails, hostlist_create() returns NULL.
  *
@@ -101,7 +101,7 @@ typedef struct hostlist_iterator * hostlist_iterator_t;
  */
 hostlist_t hostlist_create(const char *hostlist);
 
-/* hostlist_copy(): 
+/* hostlist_copy():
  *
  * Allocate a copy of a hostlist object. Returned hostlist must be freed
  * with hostlist_destroy.
@@ -123,7 +123,7 @@ void hostlist_destroy(hostlist_t hl);
  *
  * The hosts argument may take the same form as in hostlist_create()
  *
- * Returns the number of hostnames inserted into the list, 
+ * Returns the number of hostnames inserted into the list,
  * or 0 on failure.
  */
 int hostlist_push(hostlist_t hl, const char *hosts);
@@ -131,7 +131,7 @@ int hostlist_push(hostlist_t hl, const char *hosts);
 
 /* hostlist_push_host():
  *
- * Push a single host onto the hostlist hl. 
+ * Push a single host onto the hostlist hl.
  * This function is more efficient than hostlist_push() for a single
  * hostname, since the argument does not need to be checked for ranges.
  *
@@ -199,8 +199,8 @@ char * hostlist_shift_range(hostlist_t hl);
 
 /* hostlist_find():
  *
- * Searches hostlist hl for the first host matching hostname 
- * and returns position in list if found. 
+ * Searches hostlist hl for the first host matching hostname
+ * and returns position in list if found.
  *
  * Returns -1 if host is not found.
  *
@@ -219,7 +219,7 @@ int hostlist_delete(hostlist_t hl, const char *hosts);
 /* hostlist_delete_host():
  *
  * Deletes the first host that matches `hostname' from the hostlist hl.
- * Note: "hostname" argument cannot contain a range of hosts 
+ * Note: "hostname" argument cannot contain a range of hosts
  *       (see hostlist_delete() for this functionality.)
  *
  * Returns 1 if successful, 0 if hostname is not found in list.
@@ -240,7 +240,7 @@ int hostlist_delete_nth(hostlist_t hl, int n);
 /* hostlist_count():
  *
  * Return the number of hosts in hostlist hl.
- */ 
+ */
 int hostlist_count(hostlist_t hl);
 
 /* hostlist_is_empty(): return true if hostlist is empty. */
@@ -249,7 +249,7 @@ int hostlist_count(hostlist_t hl);
 /* ----[ Other hostlist operations ]---- */
 
 /* hostlist_sort():
- * 
+ *
  * Sort the hostlist hl.
  *
  */
@@ -258,7 +258,7 @@ void hostlist_sort(hostlist_t hl);
 /* hostlist_uniq():
  *
  * Sort the hostlist hl and remove duplicate entries.
- * 
+ *
  */
 void hostlist_uniq(hostlist_t hl);
 
@@ -272,7 +272,7 @@ void hostlist_uniq(hostlist_t hl);
  * or -1 if truncation occurred.
  *
  * The result will be NULL terminated.
- * 
+ *
  * hostlist_ranged_string() will write a bracketed hostlist representation
  * where possible.
  */
@@ -332,11 +332,11 @@ void hostlist_iterator_reset(hostlist_iterator_t i);
 
 /* hostlist_next():
  *
- * Returns a pointer to the  next hostname on the hostlist 
+ * Returns a pointer to the  next hostname on the hostlist
  * or NULL at the end of the list
  *
  * The caller is responsible for freeing the returned memory.
- */ 
+ */
 char * hostlist_next(hostlist_iterator_t i);
 
 

--- a/src/libcommon/list.c
+++ b/src/libcommon/list.c
@@ -29,7 +29,7 @@
  *  Copyright (C) 2001-2002 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Chris Dunlap <cdunlap@llnl.gov>.
- *  
+ *
  *  This file is from LSD-Tools, the LLNL Software Development Toolbox.
  *
  *  LSD-Tools is free software; you can redistribute it and/or modify it under

--- a/src/libcommon/list.h
+++ b/src/libcommon/list.h
@@ -4,7 +4,7 @@
  *  Copyright (C) 2001-2002 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Chris Dunlap <cdunlap@llnl.gov>.
- *  
+ *
  *  This file is from LSD-Tools, the LLNL Software Development Toolbox.
  *
  *  LSD-Tools is free software; you can redistribute it and/or modify it under

--- a/src/libcommon/thread.c
+++ b/src/libcommon/thread.c
@@ -4,7 +4,7 @@
  *  Copyright (C) 2003 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Chris Dunlap <cdunlap@llnl.gov>.
- *  
+ *
  *  This file is from LSD-Tools, the LLNL Software Development Toolbox.
  *
  *  LSD-Tools is free software; you can redistribute it and/or modify it under

--- a/src/libcommon/thread.h
+++ b/src/libcommon/thread.h
@@ -4,7 +4,7 @@
  *  Copyright (C) 2003 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Chris Dunlap <cdunlap@llnl.gov>.
- *  
+ *
  *  This file is from LSD-Tools, the LLNL Software Development Toolbox.
  *
  *  LSD-Tools is free software; you can redistribute it and/or modify it under

--- a/src/libgenders/genders.c
+++ b/src/libgenders/genders.c
@@ -46,12 +46,12 @@
 #include "hash.h"
 #include "list.h"
 
-/* 
+/*
  * genders_errmsg
  *
  * store errormsg strings
  */
-static char * genders_errmsg[] = 
+static char * genders_errmsg[] =
   {
     "success",
     "genders handle is null",
@@ -62,7 +62,7 @@ static char * genders_errmsg[] =
     "genders data already loaded",
     "array or string passed in not large enough to store result",
     "incorrect parameters passed in",
-    "null pointer reached in list", 
+    "null pointer reached in list",
     "node or attribute not found",
     "out of memory",
     "query syntax error",
@@ -71,12 +71,12 @@ static char * genders_errmsg[] =
     "error number out of range",
   };
 
-/* 
+/*
  * _initialize_handle_info
  *
  * Initialize genders_t handle
  */
-static void 
+static void
 _initialize_handle_info(genders_t handle)
 {
   handle->magic = GENDERS_MAGIC_NUM;
@@ -102,21 +102,21 @@ _initialize_handle_info(genders_t handle)
    */
 }
 
-genders_t 
-genders_handle_create(void) 
+genders_t
+genders_handle_create(void)
 {
   genders_t handle = NULL;
 
   /* Don't use the wrapper here, no errnum to set */
   if (!(handle = (genders_t)malloc(sizeof(struct genders))))
     goto cleanup;
-  
+
   _initialize_handle_info(handle);
   handle->nodeslist = NULL;
   handle->attrvalslist = NULL;
   handle->attrslist = NULL;
   handle->attrval_buflist = NULL;
-  
+
   __list_create(handle->nodeslist, _genders_list_free_genders_node);
   __list_create(handle->attrvalslist, _genders_list_free_attrvallist);
   __list_create(handle->attrslist, free);
@@ -124,12 +124,12 @@ genders_handle_create(void)
   /* node_index, attr_index created in genders_load_data.  Valbuf
    * created in genders_load_data after maxvallen is calculated
    */
-  
+
   handle->errnum = GENDERS_ERR_SUCCESS;
   return handle;
-  
+
  cleanup:
-  if (handle) 
+  if (handle)
     {
       __list_destroy(handle->nodeslist);
       __list_destroy(handle->attrvalslist);
@@ -139,7 +139,7 @@ genders_handle_create(void)
   return NULL;
 }
 
-int 
+int
 genders_handle_destroy(genders_t handle)
 {
   if (_genders_handle_error_check(handle) < 0)
@@ -167,50 +167,50 @@ genders_handle_destroy(genders_t handle)
 }
 
 int
-genders_load_data(genders_t handle, const char *filename) 
+genders_load_data(genders_t handle, const char *filename)
 {
   char *temp;
 
   if (_genders_unloaded_handle_error_check(handle) < 0)
     goto cleanup;
-  
+
   handle->node_index_size = GENDERS_NODE_INDEX_INIT_SIZE;
-  
+
   __hash_create(handle->node_index,
                 handle->node_index_size,
                 (hash_key_f)hash_key_string,
-                (hash_cmp_f)strcmp, 
+                (hash_cmp_f)strcmp,
                 NULL);
-  
+
   handle->attr_index_size = GENDERS_ATTR_INDEX_INIT_SIZE;
-  
+
   __hash_create(handle->attr_index,
                 handle->attr_index_size,
                 (hash_key_f)hash_key_string,
-                (hash_cmp_f)strcmp, 
+                (hash_cmp_f)strcmp,
                 (hash_del_f)list_destroy);
 
-  if (_genders_open_and_parse(handle, 
-			      filename, 
+  if (_genders_open_and_parse(handle,
+			      filename,
 			      &handle->numattrs,
 			      &handle->maxattrs,
 			      &handle->maxnodelen,
 			      &handle->maxattrlen,
 			      &handle->maxvallen,
-			      handle->nodeslist, 
+			      handle->nodeslist,
 			      handle->attrvalslist,
 			      handle->attrslist,
                               &(handle->node_index),
                               &(handle->node_index_size),
                               &(handle->attr_index),
                               &(handle->attr_index_size),
-			      0, 
+			      0,
 			      NULL) < 0)
     goto cleanup;
 
   handle->numnodes = list_count(handle->nodeslist);
 
-  if (gethostname(handle->nodename, GENDERS_MAXHOSTNAMELEN+1) < 0) 
+  if (gethostname(handle->nodename, GENDERS_MAXHOSTNAMELEN+1) < 0)
     {
       handle->errnum = GENDERS_ERR_INTERNAL;
       goto cleanup;
@@ -222,7 +222,7 @@ genders_load_data(genders_t handle, const char *filename)
   if ((temp = strchr(handle->nodename,'.')))
     *temp = '\0';
 #endif /* !WITH_NON_SHORTENED_HOSTNAMES */
-  
+
   handle->maxnodelen = GENDERS_MAX(strlen(handle->nodename), handle->maxnodelen);
 
   /* Create a buffer for value substitutions */
@@ -233,16 +233,16 @@ genders_load_data(genders_t handle, const char *filename)
   return 0;
 
 cleanup:
-  if (handle && handle->magic == GENDERS_ERR_MAGIC) 
+  if (handle && handle->magic == GENDERS_ERR_MAGIC)
     {
       free(handle->valbuf);
-      
+
       /* Can't pass NULL for key, so pass junk, _genders_list_is_all()
        * will ensure everything is deleted
        */
-      list_delete_all(handle->nodeslist, _genders_list_is_all, ""); 
-      list_delete_all(handle->attrvalslist, _genders_list_is_all, ""); 
-      list_delete_all(handle->attrslist, _genders_list_is_all, ""); 
+      list_delete_all(handle->nodeslist, _genders_list_is_all, "");
+      list_delete_all(handle->attrvalslist, _genders_list_is_all, "");
+      list_delete_all(handle->attrslist, _genders_list_is_all, "");
       __hash_destroy(handle->node_index);
       __hash_destroy(handle->attr_index);
       _initialize_handle_info(handle);
@@ -250,8 +250,8 @@ cleanup:
   return -1;
 }
 
-int 
-genders_errnum(genders_t handle) 
+int
+genders_errnum(genders_t handle)
 {
   if (!handle)
     return GENDERS_ERR_NULLHANDLE;
@@ -262,7 +262,7 @@ genders_errnum(genders_t handle)
 }
 
 char *
-genders_strerror(int errnum) 
+genders_strerror(int errnum)
 {
   if (errnum >= GENDERS_ERR_SUCCESS && errnum <= GENDERS_ERR_ERRNUMRANGE)
     return genders_errmsg[errnum];
@@ -271,13 +271,13 @@ genders_strerror(int errnum)
 }
 
 char *
-genders_errormsg(genders_t handle) 
+genders_errormsg(genders_t handle)
 {
   return genders_strerror(genders_errnum(handle));
 }
 
-void 
-genders_perror(genders_t handle, const char *msg) 
+void
+genders_perror(genders_t handle, const char *msg)
 {
   char *errormsg = genders_strerror(genders_errnum(handle));
 
@@ -324,8 +324,8 @@ genders_set_flags(genders_t handle, unsigned int flags)
   return 0;
 }
 
-int 
-genders_getnumnodes(genders_t handle) 
+int
+genders_getnumnodes(genders_t handle)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
@@ -334,8 +334,8 @@ genders_getnumnodes(genders_t handle)
   return handle->numnodes;
 }
 
-int 
-genders_getnumattrs(genders_t handle) 
+int
+genders_getnumattrs(genders_t handle)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
@@ -344,8 +344,8 @@ genders_getnumattrs(genders_t handle)
   return handle->numattrs;
 }
 
-int 
-genders_getmaxattrs(genders_t handle) 
+int
+genders_getmaxattrs(genders_t handle)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
@@ -354,8 +354,8 @@ genders_getmaxattrs(genders_t handle)
   return handle->maxattrs;
 }
 
-int 
-genders_getmaxnodelen(genders_t handle) 
+int
+genders_getmaxnodelen(genders_t handle)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
@@ -364,8 +364,8 @@ genders_getmaxnodelen(genders_t handle)
   return handle->maxnodelen;
 }
 
-int 
-genders_getmaxattrlen(genders_t handle) 
+int
+genders_getmaxattrlen(genders_t handle)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
@@ -374,8 +374,8 @@ genders_getmaxattrlen(genders_t handle)
   return handle->maxattrlen;
 }
 
-int 
-genders_getmaxvallen(genders_t handle) 
+int
+genders_getmaxvallen(genders_t handle)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
@@ -384,22 +384,22 @@ genders_getmaxvallen(genders_t handle)
   return handle->maxvallen;
 }
 
-/* 
+/*
  * _genders_list_create
  *
  * Generic list create for genders_nodelist_create,
  * genders_attrlist_create, and genders_vallist_create.
  *
  */
-static int 
-_genders_list_create(genders_t handle, char ***list, int len, int buflen) 
+static int
+_genders_list_create(genders_t handle, char ***list, int len, int buflen)
 {
   char **templist = NULL;
   int i = 0;
 
-  if (len > 0) 
+  if (len > 0)
     {
-      if (!list) 
+      if (!list)
 	{
 	  handle->errnum = GENDERS_ERR_PARAMETERS;
 	  return -1;
@@ -415,7 +415,7 @@ _genders_list_create(genders_t handle, char ***list, int len, int buflen)
   return len;
 
  cleanup:
-  if (templist) 
+  if (templist)
     {
       int j;
       for (j = 0; j < i; j++)
@@ -425,29 +425,29 @@ _genders_list_create(genders_t handle, char ***list, int len, int buflen)
   return -1;
 }
 
-/* 
+/*
  * _genders_list_clear
  *
  * Generic list clear for genders_nodelist_clear,
  * genders_attrlist_clear, and genders_vallist_clear.
  *
  */
-static int 
-_genders_list_clear(genders_t handle, char **list, int len, int buflen) 
+static int
+_genders_list_clear(genders_t handle, char **list, int len, int buflen)
 {
-  if (len > 0) 
+  if (len > 0)
     {
       int i;
-      
-      if (!list) 
+
+      if (!list)
 	{
 	  handle->errnum = GENDERS_ERR_PARAMETERS;
 	  return -1;
 	}
-      
-      for (i = 0; i < len; i++) 
+
+      for (i = 0; i < len; i++)
 	{
-	  if (!list[i]) 
+	  if (!list[i])
 	    {
 	      handle->errnum = GENDERS_ERR_NULLPTR;
 	      return -1;
@@ -460,21 +460,21 @@ _genders_list_clear(genders_t handle, char **list, int len, int buflen)
   return 0;
 }
 
-/* 
+/*
  * _genders_list_destroy
  *
  * Generic list destroy for genders_nodelist_destroy,
  * genders_attrlist_destroy, and genders_vallist_destroy.
  *
  */
-static int 
-_genders_list_destroy(genders_t handle, char **list, int len) 
+static int
+_genders_list_destroy(genders_t handle, char **list, int len)
 {
-  if (len > 0) 
+  if (len > 0)
     {
       int i;
-      
-      if (!list) 
+
+      if (!list)
 	{
 	  handle->errnum = GENDERS_ERR_PARAMETERS;
 	  return -1;
@@ -489,124 +489,124 @@ _genders_list_destroy(genders_t handle, char **list, int len)
   return 0;
 }
 
-int 
-genders_nodelist_create(genders_t handle, char ***list) 
+int
+genders_nodelist_create(genders_t handle, char ***list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  return _genders_list_create(handle, 
-			      list, 
-			      handle->numnodes, 
+  return _genders_list_create(handle,
+			      list,
+			      handle->numnodes,
 			      handle->maxnodelen+1);
 }
 
-int 
-genders_nodelist_clear(genders_t handle, char **list) 
+int
+genders_nodelist_clear(genders_t handle, char **list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  return _genders_list_clear(handle, 
-			     list, 
-			     handle->numnodes, 
+  return _genders_list_clear(handle,
+			     list,
+			     handle->numnodes,
 			     handle->maxnodelen+1);
 }
 
-int 
-genders_nodelist_destroy(genders_t handle, char **list) 
+int
+genders_nodelist_destroy(genders_t handle, char **list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  return _genders_list_destroy(handle, 
-			       list, 
+  return _genders_list_destroy(handle,
+			       list,
 			       handle->numnodes);
 }
 
-int 
-genders_attrlist_create(genders_t handle, char ***list) 
+int
+genders_attrlist_create(genders_t handle, char ***list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  return _genders_list_create(handle, 
-			      list, 
-			      handle->numattrs, 
+  return _genders_list_create(handle,
+			      list,
+			      handle->numattrs,
 			      handle->maxattrlen+1);
 }
 
-int 
-genders_attrlist_clear(genders_t handle, char **list) 
+int
+genders_attrlist_clear(genders_t handle, char **list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  return _genders_list_clear(handle, 
-			     list, 
-			     handle->numattrs, 
+  return _genders_list_clear(handle,
+			     list,
+			     handle->numattrs,
 			     handle->maxattrlen+1);
 }
 
-int 
-genders_attrlist_destroy(genders_t handle, char **list) 
+int
+genders_attrlist_destroy(genders_t handle, char **list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
-  
-  return _genders_list_destroy(handle, 
-			       list, 
+
+  return _genders_list_destroy(handle,
+			       list,
 			       handle->numattrs);
 }
 
-int 
-genders_vallist_create(genders_t handle, char ***list) 
+int
+genders_vallist_create(genders_t handle, char ***list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  return _genders_list_create(handle, 
-			      list, 
-			      handle->numattrs, 
+  return _genders_list_create(handle,
+			      list,
+			      handle->numattrs,
 			      handle->maxvallen+1);
 }
 
-int 
-genders_vallist_clear(genders_t handle, char **list) 
+int
+genders_vallist_clear(genders_t handle, char **list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  return _genders_list_clear(handle, 
-			     list, 
-			     handle->numattrs, 
+  return _genders_list_clear(handle,
+			     list,
+			     handle->numattrs,
 			     handle->maxvallen+1);
 }
 
-int 
-genders_vallist_destroy(genders_t handle, char **list) 
+int
+genders_vallist_destroy(genders_t handle, char **list)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  return _genders_list_destroy(handle, 
-			       list, 
+  return _genders_list_destroy(handle,
+			       list,
 			       handle->numattrs);
 }
 
-int 
-genders_getnodename(genders_t handle, char *node, int len) 
+int
+genders_getnodename(genders_t handle, char *node, int len)
 {
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  if (!node || len < 0) 
+  if (!node || len < 0)
     {
       handle->errnum = GENDERS_ERR_PARAMETERS;
       return -1;
     }
 
-  if ((strlen(handle->nodename) + 1) > len) 
+  if ((strlen(handle->nodename) + 1) > len)
     {
       handle->errnum = GENDERS_ERR_OVERFLOW;
       return -1;
@@ -617,9 +617,9 @@ genders_getnodename(genders_t handle, char *node, int len)
   return 0;
 }
 
-int 
-genders_getnodes(genders_t handle, char *nodes[], int len, 
-                 const char *attr, const char *val) 
+int
+genders_getnodes(genders_t handle, char *nodes[], int len,
+                 const char *attr, const char *val)
 {
   ListIterator itr = NULL;
   genders_node_t n;
@@ -628,7 +628,7 @@ genders_getnodes(genders_t handle, char *nodes[], int len,
   if (_genders_loaded_handle_error_check(handle) < 0)
     goto cleanup;
 
-  if ((!nodes && len > 0) || len < 0) 
+  if ((!nodes && len > 0) || len < 0)
     {
       handle->errnum = GENDERS_ERR_PARAMETERS;
       goto cleanup;
@@ -640,15 +640,15 @@ genders_getnodes(genders_t handle, char *nodes[], int len,
   if (val && !strlen(val))
     val = NULL;
 
-  if (handle->attrval_index 
+  if (handle->attrval_index
       && attr
       && val
-      && !strcmp(handle->attrval_index_attr, attr)) 
+      && !strcmp(handle->attrval_index_attr, attr))
     {
       /* Case A: Use attrval_index to find nodes */
       List l;
-      
-      if (!(l = hash_find(handle->attrval_index, val))) 
+
+      if (!(l = hash_find(handle->attrval_index, val)))
 	{
 	  /* No attributes with this value */
 	  handle->errnum = GENDERS_ERR_SUCCESS;
@@ -656,17 +656,17 @@ genders_getnodes(genders_t handle, char *nodes[], int len,
 	}
 
       __list_iterator_create(itr, l);
-      while ((n = list_next(itr))) 
+      while ((n = list_next(itr)))
 	{
 	  if (_genders_put_in_array(handle, n->name, nodes, index++, len) < 0)
 	    goto cleanup;
 	}
     }
-  else if (attr) 
+  else if (attr)
     {
       /* Case B: atleast the attr was input, so use attr_index */
       List l;
-      
+
       if (!handle->numattrs)
         {
 	  /* No attributes, so no nodes have this attr */
@@ -674,7 +674,7 @@ genders_getnodes(genders_t handle, char *nodes[], int len,
 	  return 0;
         }
 
-      if (!(l = hash_find(handle->attr_index, attr))) 
+      if (!(l = hash_find(handle->attr_index, attr)))
 	{
 	  /* No nodes have this attr */
 	  handle->errnum = GENDERS_ERR_SUCCESS;
@@ -682,29 +682,29 @@ genders_getnodes(genders_t handle, char *nodes[], int len,
 	}
 
       __list_iterator_create(itr, l);
-      while ((n = list_next(itr))) 
+      while ((n = list_next(itr)))
 	{
 	  genders_attrval_t av;
-	  
+
 	  /* val could be NULL */
 	  if (_genders_find_attrval(handle, n, attr, val, &av) < 0)
 	    goto cleanup;
-	  
+
 	  if (av && _genders_put_in_array(handle, n->name, nodes, index++, len) < 0)
 	    goto cleanup;
 	}
     }
-  else 
+  else
     {
       /* Case C: get every node */
       __list_iterator_create(itr, handle->nodeslist);
-      while ((n = list_next(itr))) 
+      while ((n = list_next(itr)))
 	{
 	  if (_genders_put_in_array(handle, n->name, nodes, index++, len) < 0)
 	    goto cleanup;
 	}
     }
-  
+
   rv = index;
   handle->errnum = GENDERS_ERR_SUCCESS;
  cleanup:
@@ -712,12 +712,12 @@ genders_getnodes(genders_t handle, char *nodes[], int len,
   return rv;
 }
 
-int 
-genders_getattr(genders_t handle, 
-		char *attrs[], 
+int
+genders_getattr(genders_t handle,
+		char *attrs[],
 		char *vals[],
-                int len, 
-		const char *node) 
+                int len,
+		const char *node)
 {
   ListIterator attrlist_itr = NULL;
   ListIterator attrvals_itr = NULL;
@@ -728,7 +728,7 @@ genders_getattr(genders_t handle,
   if (_genders_loaded_handle_error_check(handle) < 0)
     goto cleanup;
 
-  if ((!attrs && len > 0) || len < 0) 
+  if ((!attrs && len > 0) || len < 0)
     {
       handle->errnum = GENDERS_ERR_PARAMETERS;
       goto cleanup;
@@ -736,31 +736,31 @@ genders_getattr(genders_t handle,
 
   if (!node || !strlen(node))
     node = handle->nodename;
-  
+
   if (!handle->numnodes)
     {
       handle->errnum = GENDERS_ERR_NOTFOUND;
       return -1;
     }
 
-  if (!(n = hash_find(handle->node_index, node))) 
+  if (!(n = hash_find(handle->node_index, node)))
     {
       handle->errnum = GENDERS_ERR_NOTFOUND;
       return -1;
     }
 
   __list_iterator_create(attrlist_itr, n->attrlist);
-  while ((avc = list_next(attrlist_itr))) 
+  while ((avc = list_next(attrlist_itr)))
     {
       genders_attrval_t av;
-      
+
       __list_iterator_create(attrvals_itr, avc->attrvals);
-      while ((av = list_next(attrvals_itr))) 
+      while ((av = list_next(attrvals_itr)))
 	{
 	  if (_genders_put_in_array(handle, av->attr, attrs, index, len) < 0)
 	    goto cleanup;
-      
-	  if (vals && av->val) 
+
+	  if (vals && av->val)
 	    {
 	      char *valptr;
 	      if (_genders_get_valptr(handle, n, av, &valptr, NULL) < 0)
@@ -773,39 +773,39 @@ genders_getattr(genders_t handle,
       __list_iterator_destroy(attrvals_itr);
     }
   attrvals_itr = NULL;
-  
+
   rv = index;
   handle->errnum = GENDERS_ERR_SUCCESS;
  cleanup:
   __list_iterator_destroy(attrlist_itr);
   __list_iterator_destroy(attrvals_itr);
-  return rv;  
+  return rv;
 }
 
-int 
-genders_getattr_all(genders_t handle, char *attrs[], int len) 
+int
+genders_getattr_all(genders_t handle, char *attrs[], int len)
 {
-  ListIterator attrslist_itr = NULL; 
+  ListIterator attrslist_itr = NULL;
   char *attr;
   int index = 0, rv = -1;
-  
+
   if (_genders_loaded_handle_error_check(handle) < 0)
     goto cleanup;
 
-  if ((!attrs && len > 0) || len < 0) 
+  if ((!attrs && len > 0) || len < 0)
     {
       handle->errnum = GENDERS_ERR_PARAMETERS;
       goto cleanup;
     }
 
-  if (handle->numattrs > len) 
+  if (handle->numattrs > len)
     {
       handle->errnum = GENDERS_ERR_OVERFLOW;
       goto cleanup;
     }
 
   __list_iterator_create(attrslist_itr, handle->attrslist);
-  while ((attr = list_next(attrslist_itr))) 
+  while ((attr = list_next(attrslist_itr)))
     {
       if (_genders_put_in_array(handle, attr, attrs, index++, len) < 0)
 	goto cleanup;
@@ -815,15 +815,15 @@ genders_getattr_all(genders_t handle, char *attrs[], int len)
   handle->errnum = GENDERS_ERR_SUCCESS;
  cleanup:
   __list_iterator_destroy(attrslist_itr);
-  return rv;  
+  return rv;
 }
 
-int 
-genders_testattr(genders_t handle, 
-		 const char *node, 
-		 const char *attr, 
-                 char *val, 
-		 int len) 
+int
+genders_testattr(genders_t handle,
+		 const char *node,
+		 const char *attr,
+                 char *val,
+		 int len)
 {
   genders_node_t n;
   genders_attrval_t av;
@@ -833,7 +833,7 @@ genders_testattr(genders_t handle,
 
   if (!attr
       || !strlen(attr)
-      || (val && len < 0)) 
+      || (val && len < 0))
     {
       handle->errnum = GENDERS_ERR_PARAMETERS;
       return -1;
@@ -848,7 +848,7 @@ genders_testattr(genders_t handle,
       return -1;
     }
 
-  if (!(n = hash_find(handle->node_index, node))) 
+  if (!(n = hash_find(handle->node_index, node)))
     {
       handle->errnum = GENDERS_ERR_NOTFOUND;
       return -1;
@@ -857,16 +857,16 @@ genders_testattr(genders_t handle,
   if (_genders_find_attrval(handle, n, attr, NULL, &av) < 0)
     return -1;
 
-  if (av) 
+  if (av)
     {
-      if (val) 
+      if (val)
 	{
-	  if (av->val) 
+	  if (av->val)
 	    {
 	      char *valptr;
 	      if (_genders_get_valptr(handle, n, av, &valptr, NULL) < 0)
 		return -1;
-	      if ((strlen(valptr) + 1) > len) 
+	      if ((strlen(valptr) + 1) > len)
 		{
 		  handle->errnum = GENDERS_ERR_OVERFLOW;
 		  return -1;
@@ -877,16 +877,16 @@ genders_testattr(genders_t handle,
 	    memset(val, '\0', len);
 	}
     }
-  
+
   handle->errnum = GENDERS_ERR_SUCCESS;
   return ((av) ? 1 : 0);
 }
 
-int 
-genders_testattrval(genders_t handle, 
-		    const char *node, 
-                    const char *attr, 
-		    const char *val) 
+int
+genders_testattrval(genders_t handle,
+		    const char *node,
+                    const char *attr,
+		    const char *val)
 {
   genders_node_t n;
   genders_attrval_t av;
@@ -894,7 +894,7 @@ genders_testattrval(genders_t handle,
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  if (!attr || !strlen(attr)) 
+  if (!attr || !strlen(attr))
     {
       handle->errnum = GENDERS_ERR_PARAMETERS;
       return -1;
@@ -912,7 +912,7 @@ genders_testattrval(genders_t handle,
       return -1;
     }
 
-  if (!(n = hash_find(handle->node_index, node))) 
+  if (!(n = hash_find(handle->node_index, node)))
     {
       handle->errnum = GENDERS_ERR_NOTFOUND;
       return -1;
@@ -920,13 +920,13 @@ genders_testattrval(genders_t handle,
 
   if (_genders_find_attrval(handle, n, attr, val, &av) < 0)
     return -1;
-  
+
   handle->errnum = GENDERS_ERR_SUCCESS;
   return ((av) ? 1 : 0);
 }
 
-int 
-genders_isnode(genders_t handle, const char *node) 
+int
+genders_isnode(genders_t handle, const char *node)
 {
   genders_node_t n;
 
@@ -948,15 +948,15 @@ genders_isnode(genders_t handle, const char *node)
   return ((n) ? 1 : 0);
 }
 
-int 
-genders_isattr(genders_t handle, const char *attr) 
+int
+genders_isattr(genders_t handle, const char *attr)
 {
   void *ptr;
- 
+
   if (_genders_loaded_handle_error_check(handle) < 0)
     return -1;
 
-  if (!attr || !strlen(attr)) 
+  if (!attr || !strlen(attr))
     {
       handle->errnum = GENDERS_ERR_PARAMETERS;
       return -1;
@@ -974,8 +974,8 @@ genders_isattr(genders_t handle, const char *attr)
   return ((ptr) ? 1 : 0);
 }
 
-int 
-genders_isattrval(genders_t handle, const char *attr, const char *val) 
+int
+genders_isattrval(genders_t handle, const char *attr, const char *val)
 {
   ListIterator nodeslist_itr = NULL;
   genders_node_t n;
@@ -993,19 +993,19 @@ genders_isattrval(genders_t handle, const char *attr, const char *val)
       handle->errnum = GENDERS_ERR_PARAMETERS;
       goto cleanup;
     }
-  
-  if (handle->attrval_index 
-      && !strcmp(handle->attrval_index_attr, attr)) 
+
+  if (handle->attrval_index
+      && !strcmp(handle->attrval_index_attr, attr))
     {
       if (!hash_find(handle->attrval_index, val))
 	rv = 0;
       else
 	rv = 1;
-      
+
       handle->errnum = GENDERS_ERR_SUCCESS;
       return rv;
     }
-  else 
+  else
     {
       List l;
 
@@ -1016,11 +1016,11 @@ genders_isattrval(genders_t handle, const char *attr, const char *val)
         goto out;
 
       __list_iterator_create(nodeslist_itr, l);
-      while ((n = list_next(nodeslist_itr))) 
+      while ((n = list_next(nodeslist_itr)))
 	{
-	  if (_genders_find_attrval(handle, n, attr, val, &av) < 0) 
+	  if (_genders_find_attrval(handle, n, attr, val, &av) < 0)
 	    goto cleanup;
-	  if (av) 
+	  if (av)
 	    {
 	      rv = 1;
 	      handle->errnum = GENDERS_ERR_SUCCESS;
@@ -1063,14 +1063,14 @@ genders_index_attrvals(genders_t handle, const char *attr)
   if ((rv = genders_isattr(handle, attr)) < 0)
     goto cleanup;
 
-  if (!rv) 
+  if (!rv)
     {
       handle->errnum = GENDERS_ERR_NOTFOUND;
       goto cleanup;
     }
 
   /* check if index already created */
-  if (handle->attrval_index && !strcmp(handle->attrval_index_attr, attr)) 
+  if (handle->attrval_index && !strcmp(handle->attrval_index_attr, attr))
     {
       handle->errnum = GENDERS_ERR_SUCCESS;
       return 0;
@@ -1084,60 +1084,60 @@ genders_index_attrvals(genders_t handle, const char *attr)
     }
 
   /* Max possible hash size is number of nodes, so pick upper boundary */
-  __hash_create(attrval_index, 
-                handle->numnodes, 
+  __hash_create(attrval_index,
+                handle->numnodes,
                 (hash_key_f)hash_key_string,
-                (hash_cmp_f)strcmp, 
+                (hash_cmp_f)strcmp,
                 (hash_del_f)list_destroy);
 
   /* Create a List to store buffers for later freeing */
   __list_create(attrval_buflist, free);
 
   __list_iterator_create(nodeslist_itr, handle->nodeslist);
-  while ((n = list_next(nodeslist_itr))) 
+  while ((n = list_next(nodeslist_itr)))
     {
       int subst_occurred = 0;
       genders_attrval_t av;
-      
+
       if (_genders_find_attrval(handle, n, attr, NULL, &av) < 0)
 	goto cleanup;
 
-      if (av) 
+      if (av)
 	{
 	  char *valptr;
-	  
-	  if (av->val) 
+
+	  if (av->val)
 	    {
-	      if (_genders_get_valptr(handle, 
-				      n, 
-				      av, 
-				      &valptr, 
+	      if (_genders_get_valptr(handle,
+				      n,
+				      av,
+				      &valptr,
 				      &subst_occurred) < 0)
 		goto cleanup;
 	    }
 	  else
 	    valptr = GENDERS_NOVALUE;
 
-	  if (!(l = hash_find(attrval_index, valptr))) 
+	  if (!(l = hash_find(attrval_index, valptr)))
 	    {
 	      __list_create(l, NULL);
-	      
+
 	      /* If a substitution occurred, we cannot use the av->val
 	       * pointer as the key, b/c the key contains some nonsense
 	       * characters (i.e. %n).  So we have to copy this buffer and
 	       * store it somewhere to be freed later.
 	       */
-	      if (subst_occurred) 
+	      if (subst_occurred)
 		{
 		  __xstrdup(valbuf, valptr);
 		  __list_append(attrval_buflist, valbuf);
 		  valptr = valbuf;
 		  valbuf = NULL;
 		}
-	      
+
 	      __hash_insert(attrval_index, valptr, l);
 	    }
-      
+
 	  __list_append(l, n);
 	  l = NULL;
 	}
@@ -1159,7 +1159,7 @@ genders_index_attrvals(genders_t handle, const char *attr)
   __list_iterator_destroy(nodeslist_itr);
   handle->errnum = GENDERS_ERR_SUCCESS;
   return 0;
-  
+
  cleanup:
   __list_iterator_destroy(nodeslist_itr);
   __list_destroy(l);
@@ -1170,8 +1170,8 @@ genders_index_attrvals(genders_t handle, const char *attr)
   return -1;
 }
 
-int 
-genders_parse(genders_t handle, const char *filename, FILE *stream) 
+int
+genders_parse(genders_t handle, const char *filename, FILE *stream)
 {
   int errcount, rv = -1;
   int debugnumattrs = 0;
@@ -1199,29 +1199,29 @@ genders_parse(genders_t handle, const char *filename, FILE *stream)
   __hash_create(debugnode_index,
                 debugnode_index_size,
                 (hash_key_f)hash_key_string,
-                (hash_cmp_f)strcmp, 
+                (hash_cmp_f)strcmp,
                 NULL);
   __hash_create(debugattr_index,
                 debugattr_index_size,
                 (hash_key_f)hash_key_string,
-                (hash_cmp_f)strcmp, 
+                (hash_cmp_f)strcmp,
                 (hash_del_f)list_destroy);
 
-  if ((errcount = _genders_open_and_parse(handle, 
+  if ((errcount = _genders_open_and_parse(handle,
 					  filename,
 					  &debugnumattrs,
 					  &debugmaxattrs,
 					  &debugmaxnodelen,
 					  &debugmaxattrlen,
 					  &debugmaxvallen,
-					  debugnodeslist, 
+					  debugnodeslist,
 					  debugattrvalslist,
 					  debugattrslist,
                                           &(debugnode_index),
                                           &(debugnode_index_size),
                                           &(debugattr_index),
                                           &(debugattr_index_size),
-					  1, 
+					  1,
 					  stream)) < 0)
     goto cleanup;
 
@@ -1236,8 +1236,8 @@ genders_parse(genders_t handle, const char *filename, FILE *stream)
   return rv;
 }
 
-void 
-genders_set_errnum(genders_t handle, int errnum) 
+void
+genders_set_errnum(genders_t handle, int errnum)
 {
   if (_genders_handle_error_check(handle) < 0)
     return;
@@ -1245,7 +1245,7 @@ genders_set_errnum(genders_t handle, int errnum)
   handle->errnum = errnum;
 }
 
-/* 
+/*
  * _genders_copy_nodeslist
  *
  * Copy contents of the nodeslist list into the handlecopy.
@@ -1276,7 +1276,7 @@ _genders_copy_nodeslist(genders_t handle, genders_t handlecopy)
       __list_append(handlecopy->nodeslist, newn);
       newn = NULL;
     }
-  
+
   rv = 0;
  cleanup:
   if (rv < 0)
@@ -1293,7 +1293,7 @@ _genders_copy_nodeslist(genders_t handle, genders_t handlecopy)
   return rv;
 }
 
-/* 
+/*
  * _genders_copy_fill_node_index
  *
  * Add keys into the node_index
@@ -1309,7 +1309,7 @@ static int _genders_copy_fill_node_index(genders_t handle, genders_t handlecopy)
   __list_iterator_create(itr, handlecopy->nodeslist);
   while ((n = list_next(itr)))
     __hash_insert(handlecopy->node_index, n->name, n);
-  
+
   rv = 0;
  cleanup:
   if (rv < 0)
@@ -1318,7 +1318,7 @@ static int _genders_copy_fill_node_index(genders_t handle, genders_t handlecopy)
   return rv;
 }
 
-/* 
+/*
  * _genders_copy_attrvalslist
  *
  * Copy contents of the attrvalslist list into the handlecopy.
@@ -1359,11 +1359,11 @@ _genders_copy_attrvalslist(genders_t handle, genders_t handlecopy)
 	  __list_append(newavc->attrvals, newav);
 	  newav = NULL;
 	}
-      
+
       __list_append(handlecopy->attrvalslist, newavc);
       newavc = NULL;
   }
-  
+
   rv = 0;
  cleanup:
   if (rv < 0)
@@ -1385,7 +1385,7 @@ _genders_copy_attrvalslist(genders_t handle, genders_t handlecopy)
   return rv;
 }
 
-/* 
+/*
  * _genders_copy_attrslist
  *
  * Copy contents of the attrslist list into the handlecopy.
@@ -1406,7 +1406,7 @@ _genders_copy_attrslist(genders_t handle, genders_t handlecopy)
       __list_append(handlecopy->attrslist, newattr);
       newattr = NULL;
     }
-  
+
   rv = 0;
  cleanup:
   if (rv < 0)
@@ -1415,7 +1415,7 @@ _genders_copy_attrslist(genders_t handle, genders_t handlecopy)
   return rv;
 }
 
-/* 
+/*
  * _genders_copy_fill_attr_index
  *
  * Add keys into the attr_index
@@ -1457,7 +1457,7 @@ _genders_copy_find_attrvals_container(genders_t handle,
   ListIterator attrvalsitr = NULL;
   genders_attrvals_container_t rv = NULL;
   genders_attrvals_container_t avc;
-  
+
   __list_iterator_create(attrvalsitr, handlecopy->attrvalslist);
   while ((avc = list_next(attrvalsitr)))
     {
@@ -1473,7 +1473,7 @@ _genders_copy_find_attrvals_container(genders_t handle,
   return rv;
 }
 
-/* 
+/*
  * _genders_copy_fill_node
  *
  * Fill node attrlist and attrlist index.
@@ -1500,9 +1500,9 @@ _genders_copy_fill_node(genders_t handle,
 							   handlecopy,
 							   avc->index)))
 	goto cleanup;
-      
+
       __list_append(nodecopy->attrlist, tmpavc);
-      
+
       __list_iterator_create(attrvalsitr, tmpavc->attrvals);
       while ((av = list_next(attrvalsitr)))
 	{
@@ -1511,20 +1511,20 @@ _genders_copy_fill_node(genders_t handle,
 	  __hash_insert(nodecopy->attrlist_index,
 			av->attr,
 			tmpavc);
-	  
+
 	  if (!(l = hash_find(handlecopy->attr_index, av->attr)))
 	    {
 	      handle->errnum = GENDERS_ERR_INTERNAL;
 	      goto cleanup;
 	    }
-	  
+
 	  __list_append(l, nodecopy);
 	}
-      
+
       __list_iterator_destroy(attrvalsitr);
       attrvalsitr = NULL;
     }
-  
+
   rv = 0;
  cleanup:
   __list_iterator_destroy(attrlistitr);
@@ -1532,7 +1532,7 @@ _genders_copy_fill_node(genders_t handle,
   return rv;
 }
 
-/* 
+/*
  * _genders_copy_fill_node_data
  *
  * Fill node attrlist and attrlist index.
@@ -1563,7 +1563,7 @@ _genders_copy_fill_node_data(genders_t handle, genders_t handlecopy)
 				  nodecopy) < 0)
 	goto cleanup;
     }
-  
+
   rv = 0;
  cleanup:
   __list_iterator_destroy(nodeslistitr);
@@ -1571,7 +1571,7 @@ _genders_copy_fill_node_data(genders_t handle, genders_t handlecopy)
 }
 
 genders_t
-genders_copy(genders_t handle) 
+genders_copy(genders_t handle)
 {
   genders_t handlecopy = NULL;
 
@@ -1594,7 +1594,7 @@ genders_copy(genders_t handle)
   handlecopy->maxvallen = handle->maxvallen;
 
   memcpy(handlecopy->nodename, handle->nodename, GENDERS_MAXHOSTNAMELEN+1);
-  
+
   if (_genders_copy_nodeslist(handle, handlecopy) < 0)
     goto cleanup;
 
@@ -1616,7 +1616,7 @@ genders_copy(genders_t handle)
     goto cleanup;
 
   handlecopy->attr_index_size = handle->attr_index_size;
-  
+
   __hash_create(handlecopy->attr_index,
                 handlecopy->attr_index_size,
                 (hash_key_f)hash_key_string,
@@ -1625,7 +1625,7 @@ genders_copy(genders_t handle)
 
   if (_genders_copy_fill_attr_index(handle, handlecopy) < 0)
     goto cleanup;
-  
+
   if (_genders_copy_fill_node_data(handle, handlecopy) < 0)
     goto cleanup;
 

--- a/src/libgenders/genders_api.h
+++ b/src/libgenders/genders_api.h
@@ -35,7 +35,7 @@
 #define GENDERS_MAGIC_NUM                0xdeadbeef
 
 /* Impossible to have a genders value with spaces */
-#define GENDERS_NOVALUE                  "  NOVAL  "   
+#define GENDERS_NOVALUE                  "  NOVAL  "
 
 #define GENDERS_NODE_INDEX_INIT_SIZE     2048
 
@@ -43,7 +43,7 @@
 
 #define GENDERS_ATTRLIST_INDEX_INIT_SIZE 128
 
-/* 
+/*
  * struct genders_node
  *
  * stores node name and a list of pointers to attrval lists containing
@@ -61,10 +61,10 @@ struct genders_node {
 };
 typedef struct genders_node *genders_node_t;
 
-/* 
+/*
  * struct genders_attrval
  *
- * stores attribute name and its value (if no value, val == NULL) 
+ * stores attribute name and its value (if no value, val == NULL)
  */
 struct genders_attrval {
   char *attr;
@@ -86,15 +86,15 @@ struct genders_attrvals_container {
 };
 typedef struct genders_attrvals_container *genders_attrvals_container_t;
 
-/* 
+/*
  * struct genders
- * 
+ *
  * Genders handle, caches all information loaded from a genders
  * database.  Consider the following genders database
  *
  * nodename[1-2]  attrname1=val1,attrname2=val2
  * nodename1      attrname3=val3,attrname4
- * nodename2      attrname5   
+ * nodename2      attrname5
  * nodename3      attrname6
  *
  * After the genders database has been loaded using genders_load_data,
@@ -104,7 +104,7 @@ typedef struct genders_attrvals_container *genders_attrvals_container_t;
  * errnum = current error code
  * is_loaded = 1
  * numnodes = 3
- * numattrs = 6 
+ * numattrs = 6
  * maxattrs = 4
  * maxnodelen = 9
  * maxattrlen = 5
@@ -136,9 +136,9 @@ typedef struct genders_attrvals_container *genders_attrvals_container_t;
  *      attr4.attr = attrname4, attr4.val = NULL
  *      attr5.attr = attrname5, attr5.val = NULL
  *      attr6.attr = attrname6, attr6.val = NULL
- * attrslist = attrname1 -> attrname2 -> attrname3 -> attrname4 -> 
+ * attrslist = attrname1 -> attrname2 -> attrname3 -> attrname4 ->
  *             attrname5 -> attrname6 -> \0
- * valbuf -> buffer of length 5 (maxvallen + 1) 
+ * valbuf -> buffer of length 5 (maxvallen + 1)
  *
  * node_index = hash table with
  *              KEY(nodename1): node1
@@ -151,10 +151,10 @@ typedef struct genders_attrvals_container *genders_attrvals_container_t;
  *              KEY(attrname3): node1
  *              KEY(attrname4): node1
  *              KEY(attrname5): node2
- *              KEY(attrname6): node3 
+ *              KEY(attrname6): node3
  */
 struct genders {
-  int magic;                                /* magic number */ 
+  int magic;                                /* magic number */
   int errnum;                               /* error code */
   int is_loaded;                            /* genders loaded flag */
   unsigned int flags;                       /* flags for alternate behavior */

--- a/src/libgenders/genders_constants.h
+++ b/src/libgenders/genders_constants.h
@@ -32,6 +32,6 @@
 #define GENDERS_BUFLEN            65536
 
 /* Impossible to have a genders value with spaces */
-#define GENDERS_NOVALUE           "  NOVAL  "   
+#define GENDERS_NOVALUE           "  NOVAL  "
 
 #endif /* _GENDERS_CONSTANTS_H */

--- a/src/libgenders/genders_parsing.c
+++ b/src/libgenders/genders_parsing.c
@@ -49,7 +49,7 @@
 #include "hostlist.h"
 #include "list.h"
 
-/* 
+/*
  * _insert_node
  *
  * Insert a node into the nodelist and node index.
@@ -65,7 +65,7 @@ _insert_node(genders_t handle,
 {
   genders_node_t n = NULL;
 
-  /* must create node if node doesn't exist */ 
+  /* must create node if node doesn't exist */
   if (!(n = hash_find((*node_index), nodename)))
     {
       /* insert into nodelist */
@@ -79,7 +79,7 @@ _insert_node(genders_t handle,
                     (hash_key_f)hash_key_string,
                     (hash_cmp_f)strcmp,
                     NULL);
-      
+
       __list_append(nodelist, n);
 
       /* insert into node_index */
@@ -93,9 +93,9 @@ _insert_node(genders_t handle,
       __hash_insert((*node_index), n->name, n);
     }
   return n;
-  
+
  cleanup:
-  if (n) 
+  if (n)
     {
       __list_destroy(n->attrlist);
       __hash_destroy(n->attrlist_index);
@@ -104,15 +104,15 @@ _insert_node(genders_t handle,
   return NULL;
 }
 
-/* 
+/*
  * _insert_attrval
  *
  * Insert an attrval into the attrvallist.
  *
  * Returns 0 on success, -1 on error
  */
-static int 
-_insert_attrval(genders_t handle, genders_attrvals_container_t avc, char *attr, char *val) 
+static int
+_insert_attrval(genders_t handle, genders_attrvals_container_t avc, char *attr, char *val)
 {
   genders_attrval_t av = NULL;
 
@@ -120,20 +120,20 @@ _insert_attrval(genders_t handle, genders_attrvals_container_t avc, char *attr, 
   av->val_contains_subst = 0;
 
   __xstrdup(av->attr, attr);
-  if (val) 
+  if (val)
     {
       __xstrdup(av->val, val);
       if (strstr(av->val, "%n") || strstr(av->val, "%%"))
 	av->val_contains_subst = 1;
     }
-  else 
-    av->val = NULL; 
+  else
+    av->val = NULL;
 
   __list_append(avc->attrvals, av);
 
   return 0;
  cleanup:
-  if (av) 
+  if (av)
     {
       free(av->attr);
       free(av->val);
@@ -142,19 +142,19 @@ _insert_attrval(genders_t handle, genders_attrvals_container_t avc, char *attr, 
   return -1;
 }
 
-/* 
+/*
  * _insert_attr
  *
  * Insert an attr into the attrlist and attr_index
  *
  * Returns 0 on success, -1 on error
  */
-static int 
+static int
 _insert_attr(genders_t handle,
 	     List attrslist,
              hash_t *attr_index,
              int *attr_index_size,
-             char *attr) 
+             char *attr)
 {
   List l = NULL;
   char *attr_new = NULL;
@@ -184,7 +184,7 @@ _insert_attr(genders_t handle,
   return -1;
 }
 
-/* 
+/*
  * _attr_node_processing
  *
  * Determine if an attr in the attrvallist already exists for the
@@ -195,8 +195,8 @@ _insert_attr(genders_t handle,
  * If line_num == 0, returns 0 on success, -1 on error
  */
 static int
-_attr_node_processing(genders_t handle, 
-                      genders_node_t n, 
+_attr_node_processing(genders_t handle,
+                      genders_node_t n,
                       genders_attrvals_container_t avc,
                       hash_t *attr_index,
                       int line_num,
@@ -211,7 +211,7 @@ _attr_node_processing(genders_t handle,
 
   /* First check for parse errors */
   __list_iterator_create(attrvals_itr, avc->attrvals);
-  while ((av = list_next(attrvals_itr))) 
+  while ((av = list_next(attrvals_itr)))
     {
       /* do not use _genders_find_attrval().  If the attrval already
        * exists within the node, we don't need the actual entry.  We
@@ -222,7 +222,7 @@ _attr_node_processing(genders_t handle,
       if (hash_find(n->attrlist_index, av->attr)
 	  || list_find_first(tmpattrlist, _genders_list_is_str, av->attr))
 	{
-	  if (line_num > 0) 
+	  if (line_num > 0)
 	    {
 	      fprintf(stream, "Line %d: duplicate attribute \"%s\" listed for node \"%s\"\n",
 		      line_num, av->attr, n->name);
@@ -231,13 +231,13 @@ _attr_node_processing(genders_t handle,
 	  handle->errnum = GENDERS_ERR_PARSE;
 	  goto cleanup;
 	}
-      
+
       __list_append(tmpattrlist, av->attr);
     }
 
   /* If no parse errors, insert everything as needed */
   list_iterator_reset(attrvals_itr);
-  while ((av = list_next(attrvals_itr))) 
+  while ((av = list_next(attrvals_itr)))
     {
       /* do not use _genders_find_attrval().  If the attrval already
        * exists within the node, we don't need the actual entry.  We
@@ -246,7 +246,7 @@ _attr_node_processing(genders_t handle,
        */
       if (hash_find(n->attrlist_index, av->attr))
 	{
-	  if (line_num > 0) 
+	  if (line_num > 0)
 	    {
 	      fprintf(stream, "Line %d: duplicate attribute \"%s\" listed for node \"%s\"\n",
 		      line_num, av->attr, n->name);
@@ -277,12 +277,12 @@ _attr_node_processing(genders_t handle,
           if (_genders_rehash(handle, &(n->attrlist_index), &(n->attrlist_index_size)) < 0)
             goto cleanup;
         }
-      
+
       __hash_insert(n->attrlist_index,
                     av->attr,
                     avc);
     }
-  
+
   rv = 0;
  cleanup:
   __list_iterator_destroy(attrvals_itr);
@@ -291,7 +291,7 @@ _attr_node_processing(genders_t handle,
 }
 
 #ifndef HAVE_STRSEP
-/* 
+/*
  * strsep for those systems that do not define it.
  *
  * Taken straight from glibc
@@ -355,23 +355,23 @@ strsep (char **stringp, const char *delim)
  * change our minds later concerning whether and empty genders file
  * is acceptable.
  */
-static int 
-_parse_line(genders_t handle, 
+static int
+_parse_line(genders_t handle,
 	    int *numattrs,
 	    int *maxattrs,
 	    int *maxnodelen,
 	    int *maxattrlen,
 	    int *maxvallen,
-	    List nodeslist, 
-	    List attrvalslist, 
+	    List nodeslist,
+	    List attrvalslist,
 	    List attrslist,
             hash_t *node_index,
             int *node_index_size,
             hash_t *attr_index,
             int *attr_index_size,
-            char *line, 
-	    int line_num, 
-	    FILE *stream, 
+            char *line,
+	    int line_num,
+	    FILE *stream,
 	    int *parsed_nodes)
 {
   char *temp, *nodenames, *node = NULL;
@@ -381,12 +381,12 @@ _parse_line(genders_t handle,
   hostlist_iterator_t hlitr = NULL;
 
   /* "remove" comments */
-  if ((temp = strchr(line, '#'))) 
+  if ((temp = strchr(line, '#')))
     *temp = '\0';
 
   /* remove trailing white space, including newline */
   temp = line + strlen(line);
-  for (--temp; temp >= line; temp--) 
+  for (--temp; temp >= line; temp--)
     {
       if (isspace(*temp))
 	*temp = '\0';
@@ -399,7 +399,7 @@ _parse_line(genders_t handle,
     return 0;
 
   /* move forward to node name(s) */
-  while(isspace(*line))  
+  while(isspace(*line))
     line++;
 
   /* get node name(s) */
@@ -410,22 +410,22 @@ _parse_line(genders_t handle,
   *parsed_nodes = 1;
 
   /* if strsep() sets line == NULL, line has no attributes */
-  if (line) 
+  if (line)
     {
       char *attr;
 
       /* move forward to attributes */
-      while(isspace(*line))  
+      while(isspace(*line))
 	line++;
-      
+
       /* *line == '\0' means line has no attributes */
-      if (*line != '\0') 
+      if (*line != '\0')
 	{
           int insert_count;
 
-	  if (strchr(line,' ') || strchr(line,'\t')) 
+	  if (strchr(line,' ') || strchr(line,'\t'))
 	    {
-	      if (line_num > 0) 
+	      if (line_num > 0)
 		{
 		  fprintf(stream, "Line %d: white space in attribute list\n", line_num);
 		  rv = 1;
@@ -439,13 +439,13 @@ _parse_line(genders_t handle,
 		    sizeof(struct genders_attrvals_container));
 	  __list_create(avc->attrvals, _genders_list_free_genders_attrval);
 	  avc->index = list_count(handle->attrvalslist);
-	  
+
 	  /* parse attributes */
 	  attr = strsep(&line, ",");
-	  while (attr) 
+	  while (attr)
 	    {
 	      char *val = NULL;
-	      
+
 	      /* parse value out of attribute */
 	      if ((val = strchr(attr,'=')))
 		*val++ = '\0';
@@ -463,10 +463,10 @@ _parse_line(genders_t handle,
 		  goto cleanup;
                 }
 #endif
-	
+
 	      if (!strlen(attr))
 		{
-		  if (line_num > 0) 
+		  if (line_num > 0)
 		    {
 		      fprintf(stream, "Line %d: empty string attribute listed\n", line_num);
 		      rv = 1;
@@ -477,7 +477,7 @@ _parse_line(genders_t handle,
 
 	      if (val && !strlen(val))
 		{
-		  if (line_num > 0) 
+		  if (line_num > 0)
 		    {
 		      fprintf(stream, "Line %d: no value specified for attribute \"%s\"\n",
 			      line_num, attr);
@@ -492,23 +492,23 @@ _parse_line(genders_t handle,
                * caught during duplicate attribute checks within each
                * node below.
                */
-      
+
 	      if (_insert_attrval(handle, avc, attr, val) < 0)
 		goto cleanup;
-	      
+
               if ((insert_count = _insert_attr(handle,
 					       attrslist,
                                                attr_index,
                                                attr_index_size,
                                                attr)) < 0)
                 goto cleanup;
-		  
-	      if (!line_num) 
+
+	      if (!line_num)
 		{
 		  (*numattrs) += insert_count;
 		  (*maxattrlen) = GENDERS_MAX(strlen(attr), (*maxattrlen));
 
-		  if (val) 
+		  if (val)
 		    {
 		      if (strstr(val, "%n") && !strstr(val, "%%n"))
 			max_n_subst_vallen = strlen(val);
@@ -516,16 +516,16 @@ _parse_line(genders_t handle,
 			(*maxvallen) = GENDERS_MAX(strlen(val), (*maxvallen));
 		    }
 		}
-	      
+
 	      attr = strsep(&line, ",");
 	    }
 	}
     }
-  
+
 #ifndef WITH_NON_SHORTENED_HOSTNAMES
-  if (strchr(nodenames, '.')) 
+  if (strchr(nodenames, '.'))
     {
-      if (line_num > 0) 
+      if (line_num > 0)
 	{
 	  fprintf(stream, "Line %d: node not a shortened hostname\n", line_num);
 	  rv = 1;
@@ -539,7 +539,7 @@ _parse_line(genders_t handle,
 
   if (!hostlist_push(hl, nodenames))
     {
-      if (line_num > 0) 
+      if (line_num > 0)
 	{
 	  fprintf(stream, "Line %d: incorrectly specified nodename(s)\n", line_num);
 	  rv = 1;
@@ -550,13 +550,13 @@ _parse_line(genders_t handle,
 
   __hostlist_iterator_create(hlitr, hl);
 
-  while ((node = hostlist_next(hlitr))) 
+  while ((node = hostlist_next(hlitr)))
     {
       genders_node_t n;
 
-      if (strlen(node) > GENDERS_MAXHOSTNAMELEN) 
+      if (strlen(node) > GENDERS_MAXHOSTNAMELEN)
 	{
-	  if (line_num > 0) 
+	  if (line_num > 0)
 	    {
 	      fprintf(stream, "Line %d: hostname too long\n", line_num);
 	      rv = 1;
@@ -564,15 +564,15 @@ _parse_line(genders_t handle,
 	  handle->errnum = GENDERS_ERR_PARSE;
 	  goto cleanup;
 	}
-  
+
       if (!(n = _insert_node(handle,
                              nodeslist,
                              node_index,
                              node_index_size,
                              node)))
 	goto cleanup;
-      
-      if (avc) 
+
+      if (avc)
 	{
 	  if ((rv = _attr_node_processing(handle,
                                           n,
@@ -585,30 +585,30 @@ _parse_line(genders_t handle,
           __list_append(n->attrlist, avc);
 	  n->attrcount += list_count(avc->attrvals);
 	}
-      
-      if (!line_num) 
+
+      if (!line_num)
 	{
 	  (*maxattrs) = GENDERS_MAX(n->attrcount, (*maxattrs));
 	  (*maxnodelen) = GENDERS_MAX(strlen(node), (*maxnodelen));
 	  line_maxnodelen = GENDERS_MAX(strlen(node), line_maxnodelen);
 	}
-      
+
       free(node);
     }
   node = NULL;
-  
+
   /* %n substitution found on this line, update maxvallen */
   if (!line_num && max_n_subst_vallen)
     (*maxvallen) = GENDERS_MAX(max_n_subst_vallen - 2 + line_maxnodelen,
 			       (*maxvallen));
-  
+
   /* Append at the very end, so cleanup area cleaner */
-  if (avc) 
+  if (avc)
     {
       __list_append(attrvalslist, avc);
       avc = NULL;
     }
-  
+
   rv = 0;
  cleanup:
   __hostlist_iterator_destroy(hlitr);
@@ -672,26 +672,26 @@ _genders_open_and_parse(genders_t handle,
           break;
         }
 
-      if ((bug_count = _parse_line(handle, 
+      if ((bug_count = _parse_line(handle,
 				   numattrs,
 				   maxattrs,
 				   maxnodelen,
 				   maxattrlen,
-				   maxvallen,				   
-				   nodeslist, 
-				   attrvalslist, 
+				   maxvallen,
+				   nodeslist,
+				   attrvalslist,
 				   attrslist,
                                    node_index,
                                    node_index_size,
                                    attr_index,
                                    attr_index_size,
-				   buf, 
-				   (debug) ? line_count : 0, 
-				   stream, 
+				   buf,
+				   (debug) ? line_count : 0,
+				   stream,
 				   &parsed_nodes)) < 0)
 	goto cleanup;
-      
-      if (debug) 
+
+      if (debug)
 	{
 	  if (bug_count)
 	    errcount++;
@@ -705,17 +705,17 @@ _genders_open_and_parse(genders_t handle,
       goto cleanup;
     }
 
-  if (len < 0) 
+  if (len < 0)
     {
-      if (debug && handle->errnum == GENDERS_ERR_OVERFLOW) 
+      if (debug && handle->errnum == GENDERS_ERR_OVERFLOW)
 	{
 	  fprintf(stream, "Line %d: exceeds maximum allowed length\n", line_count);
 	  rv = ++errcount;
-	  handle->errnum = GENDERS_ERR_PARSE;    
+	  handle->errnum = GENDERS_ERR_PARSE;
 	}
       goto cleanup;
     }
-  
+
 #if 0
 
   /* achu: Later discussions lead several developers to conclude an
@@ -723,9 +723,9 @@ _genders_open_and_parse(genders_t handle,
    * here for legacy documentation.
    */
 
-  if (list_count(nodeslist) == 0) 
+  if (list_count(nodeslist) == 0)
     {
-      if (debug) 
+      if (debug)
 	{
 	  fprintf(stream, "No nodes successfully parsed\n");
 
@@ -740,7 +740,7 @@ _genders_open_and_parse(genders_t handle,
       goto cleanup;
     }
 #endif
-  
+
   rv = (debug) ? errcount : 0;
  cleanup:
   /* ignore potential error, just return results */

--- a/src/libgenders/genders_parsing.h
+++ b/src/libgenders/genders_parsing.h
@@ -34,7 +34,7 @@
 #include "hash.h"
 #include "list.h"
 
-/* 
+/*
  * _genders_open_and_parse
  *
  * Common file open and file parsing function for genders_load_data

--- a/src/libgenders/genders_util.c
+++ b/src/libgenders/genders_util.c
@@ -41,14 +41,14 @@
 #include "hostlist.h"
 #include "list.h"
 
-int 
-_genders_list_is_all(void *x, void *key) 
+int
+_genders_list_is_all(void *x, void *key)
 {
   return 1;
 }
 
-int 
-_genders_list_is_str(void *x, void *key) 
+int
+_genders_list_is_str(void *x, void *key)
 {
   if (!strcmp((char *)x, (char *)key))
     return 1;
@@ -66,8 +66,8 @@ _genders_list_is_attr_in_attrvals(void *x, void *key)
   return 0;
 }
 
-void 
-_genders_list_free_genders_node(void *x) 
+void
+_genders_list_free_genders_node(void *x)
 {
   genders_node_t n;
 
@@ -78,8 +78,8 @@ _genders_list_free_genders_node(void *x)
   free(n);
 }
 
-void 
-_genders_list_free_genders_attrval(void *x) 
+void
+_genders_list_free_genders_attrval(void *x)
 {
   genders_attrval_t av;
 
@@ -99,58 +99,58 @@ _genders_list_free_attrvallist(void *x)
   free(avc);
 }
 
-int 
-_genders_handle_error_check(genders_t handle) 
+int
+_genders_handle_error_check(genders_t handle)
 {
   if (!handle || handle->magic != GENDERS_MAGIC_NUM)
     return -1;
   return 0;
 }
 
-int 
-_genders_unloaded_handle_error_check(genders_t handle) 
+int
+_genders_unloaded_handle_error_check(genders_t handle)
 {
   if (_genders_handle_error_check(handle) < 0)
     return -1;
 
-  if (handle->is_loaded) 
+  if (handle->is_loaded)
     {
       handle->errnum = GENDERS_ERR_ISLOADED;
       return -1;
     }
-  
-  return 0;
-}
 
-int 
-_genders_loaded_handle_error_check(genders_t handle) 
-{
-  if (_genders_handle_error_check(handle) < 0)
-    return -1;
-
-  if (!handle->is_loaded) 
-    {
-      handle->errnum = GENDERS_ERR_NOTLOADED;
-      return -1;
-    }
-  
   return 0;
 }
 
 int
-_genders_put_in_array(genders_t handle, 
-		      char *str, 
-		      char **list, 
-		      int index, 
+_genders_loaded_handle_error_check(genders_t handle)
+{
+  if (_genders_handle_error_check(handle) < 0)
+    return -1;
+
+  if (!handle->is_loaded)
+    {
+      handle->errnum = GENDERS_ERR_NOTLOADED;
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+_genders_put_in_array(genders_t handle,
+		      char *str,
+		      char **list,
+		      int index,
 		      int len)
 {
-  if (index >= len) 
+  if (index >= len)
     {
       handle->errnum = GENDERS_ERR_OVERFLOW;
       return -1;
     }
 
-  if (!list[index]) 
+  if (!list[index])
     {
       handle->errnum = GENDERS_ERR_NULLPTR;
       return -1;
@@ -161,9 +161,9 @@ _genders_put_in_array(genders_t handle,
 }
 
 int
-_genders_get_valptr(genders_t handle, 
-		    genders_node_t n, 
-		    genders_attrval_t av, 
+_genders_get_valptr(genders_t handle,
+		    genders_node_t n,
+		    genders_attrval_t av,
 		    char **val,
 		    int *subst_occurred)
 {
@@ -181,19 +181,19 @@ _genders_get_valptr(genders_t handle,
   valbufptr = handle->valbuf;
   valptr = av->val;
   memset(valbufptr, '\0', handle->maxvallen + 1);
-  while (*valptr != '\0') 
+  while (*valptr != '\0')
     {
-      if (*valptr == '%') 
+      if (*valptr == '%')
 	{
-	  if ((*(valptr + 1)) == '%') 
+	  if ((*(valptr + 1)) == '%')
 	    {
 	      *(valbufptr)++ = '%';
 	      valptr++;
 	    }
-	  else if ((*(valptr + 1)) == 'n') 
+	  else if ((*(valptr + 1)) == 'n')
 	    {
-	      if ((strlen(av->val) - 2 + strlen(n->name)) > 
-		  (handle->maxvallen + 1)) 
+	      if ((strlen(av->val) - 2 + strlen(n->name)) >
+		  (handle->maxvallen + 1))
 		{
 		  handle->errnum = GENDERS_ERR_INTERNAL;
 		  return -1;
@@ -207,9 +207,9 @@ _genders_get_valptr(genders_t handle,
 	  else
 	    *(valbufptr)++ = *valptr;
 	}
-      else 
+      else
 	*(valbufptr)++ = *valptr;
-      
+
       valptr++;
     }
 
@@ -220,38 +220,38 @@ _genders_get_valptr(genders_t handle,
 }
 
 int
-_genders_find_attrval(genders_t handle, 
-		      genders_node_t n, 
-		      const char *attr, 
+_genders_find_attrval(genders_t handle,
+		      genders_node_t n,
+		      const char *attr,
 		      const char *val,
 		      genders_attrval_t *avptr)
 {
   genders_attrvals_container_t avc;
   int retval = -1;
-  
+
   *avptr = NULL;
 
   if ((avc = hash_find(n->attrlist_index, attr)))
     {
       genders_attrval_t av;
-      
-      if ((av = list_find_first(avc->attrvals, 
-				_genders_list_is_attr_in_attrvals, 
-				(char *)attr))) 
+
+      if ((av = list_find_first(avc->attrvals,
+				_genders_list_is_attr_in_attrvals,
+				(char *)attr)))
 	{
-	  if (!val) 
+	  if (!val)
 	    {
 	      *avptr = av;
               goto out;
 	    }
-	  else if (av->val) 
+	  else if (av->val)
 	    {
 	      char *valptr;
-	      
+
 	      if (_genders_get_valptr(handle, n, av, &valptr, NULL) < 0)
 		goto cleanup;
 
-	      if (!strcmp(valptr, val)) 
+	      if (!strcmp(valptr, val))
 		{
 		  *avptr = av;
                   goto out;
@@ -260,10 +260,10 @@ _genders_find_attrval(genders_t handle,
 	}
     }
 
- out:  
+ out:
   retval = 0;
  cleanup:
-  return retval;  
+  return retval;
 }
 
 static int
@@ -272,7 +272,7 @@ _hash_reinsert(void *data, const void *key, void *arg)
   hash_t newhash;
 
   newhash = *((hash_t *)arg);
-  
+
   /* return -1 will result in GENDERS_ERR_INTERNAL in caller */
   if (hash_insert(newhash, key, data) < 0)
     return -1;
@@ -340,7 +340,7 @@ _genders_hash_copy(genders_t handle,
       handle->errnum = GENDERS_ERR_INTERNAL;
       goto cleanup;
     }
-  
+
   retval = 0;
  cleanup:
   return retval;

--- a/src/libgenders/genders_util.h
+++ b/src/libgenders/genders_util.h
@@ -127,27 +127,27 @@
 
 #define GENDERS_MAX(x,y) ((x > y) ? x : y)
 
-/* 
- * List API Helper Functions 
+/*
+ * List API Helper Functions
  */
 
-/* 
+/*
  * _genders_list_is_all
  *
  * Returns 1
  */
-int _genders_list_is_all(void *x, void *key); 
+int _genders_list_is_all(void *x, void *key);
 
-/* 
+/*
  * _genders_list_is_str
  *
  * x points to a string
- *  
+ *
  * Returns 1 if string x is equal to key, 0 otherwise
  */
-int _genders_list_is_str(void *x, void *key); 
+int _genders_list_is_str(void *x, void *key);
 
-/* 
+/*
  * _genders_list_is_attr_in_attrvals
  *
  * x points to a genders_attrval_t
@@ -156,32 +156,32 @@ int _genders_list_is_str(void *x, void *key);
  */
 int _genders_list_is_attr_in_attrvals(void *x, void *key);
 
-/* 
+/*
  * _genders_list_free_genders_node
  *
  * Free genders_node_t structure
  */
-void _genders_list_free_genders_node(void *x); 
+void _genders_list_free_genders_node(void *x);
 
-/* 
+/*
  * _genders_list_free_genders_attrval
  *
  * Free genders_attrval_t structure
  */
-void _genders_list_free_genders_attrval(void *x); 
+void _genders_list_free_genders_attrval(void *x);
 
-/* 
+/*
  * _genders_list_free_genders_attrvalllist
  *
  * Free list of genders_attrval_t structures
  */
 void _genders_list_free_attrvallist(void *x);
 
-/* 
- * Common helper functions 
+/*
+ * Common helper functions
  */
 
-/*  
+/*
  * _genders_handle_error_check
  *
  * Check if handle is proper
@@ -190,7 +190,7 @@ void _genders_list_free_attrvallist(void *x);
  */
 int _genders_handle_error_check(genders_t handle);
 
-/* 
+/*
  * _genders_unloaded_handle_error_check
  *
  * Check if handle is proper and unloaded
@@ -199,7 +199,7 @@ int _genders_handle_error_check(genders_t handle);
  */
 int _genders_unloaded_handle_error_check(genders_t handle);
 
-/* 
+/*
  * _genders_loaded_handle_error_check
  *
  * Check if handle is proper and loaded
@@ -208,46 +208,46 @@ int _genders_unloaded_handle_error_check(genders_t handle);
  */
 int _genders_loaded_handle_error_check(genders_t handle);
 
-/* 
+/*
  * _genders_put_in_array
  *
  * Put str in list, doing appropriate checks
  *
  * Return 0 on success, -1 on error
  */
-int _genders_put_in_array(genders_t handle, 
-			  char *str, 
-			  char **list, 
-			  int index, 
+int _genders_put_in_array(genders_t handle,
+			  char *str,
+			  char **list,
+			  int index,
 			  int len);
 
-/* 
+/*
  * _genders_get_valptr
  *
  * Return av->val or handle->valbuf depending on if substitution if required.
  *
  * Return 0 on success, -1 on error
  */
-int _genders_get_valptr(genders_t handle, 
-			genders_node_t n, 
-			genders_attrval_t av, 
+int _genders_get_valptr(genders_t handle,
+			genders_node_t n,
+			genders_attrval_t av,
 			char **val,
 			int *subst_occurred);
 
-/* 
+/*
  * _genders_find_attrval
  *
  * Find genders_attrval_t with attr or attr=val in a node
  *
  * Return 0 on success, -1 on error
  */
-int _genders_find_attrval(genders_t handle, 
-			  genders_node_t n, 
-			  const char *attr, 
+int _genders_find_attrval(genders_t handle,
+			  genders_node_t n,
+			  const char *attr,
 			  const char *val,
 			  genders_attrval_t *avptr);
 
-/* 
+/*
  * _genders_rehash
  *
  * Rehash the specified hash into a larger hash.  Both hash_ptr and

--- a/src/nodeattr/nodeattr.c
+++ b/src/nodeattr/nodeattr.c
@@ -6,20 +6,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
  *  UCRL-CODE-2003-004.
- *  
+ *
  *  This file is part of Genders, a cluster configuration database.
  *  For details, see <http://www.llnl.gov/linux/genders/>.
- *  
+ *
  *  Genders is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Genders is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Genders.  If not, see <http://www.gnu.org/licenses/>.
 \*****************************************************************************/
@@ -37,7 +37,7 @@
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */
-#if HAVE_GETOPT_H 
+#if HAVE_GETOPT_H
 #include <getopt.h>
 #endif /* HAVE_GETOPT_H */
 #include <errno.h>
@@ -163,7 +163,7 @@ main(int argc, char *argv[])
         case 'f':   /* --filename */
             filename = optarg;
             break;
-        case 'k':   /* --check */ 
+        case 'k':   /* --check */
             kopt = 1;
             break;
         case 'd':   /* --diff */
@@ -215,9 +215,9 @@ main(int argc, char *argv[])
         usage();
 
     /* specified correctly number of arguments */
-    if ((qopt 
+    if ((qopt
          && ((!Aopt && optind != (argc - 1))
-             || (Aopt && optind != argc))) 
+             || (Aopt && optind != argc)))
         || (!qopt
             && !Qopt
             && !Vopt
@@ -287,7 +287,7 @@ main(int argc, char *argv[])
         char *query;
 
         if (Aopt)
-            list_nodes(gp, NULL, excludequery, qfmt); 
+            list_nodes(gp, NULL, excludequery, qfmt);
         else {
             query = argv[optind++];
             list_nodes(gp, query, excludequery, qfmt);
@@ -356,7 +356,7 @@ main(int argc, char *argv[])
     exit(0);
 }
 
-static void 
+static void
 list_nodes(genders_t gp, char *query, char *excludequery, fmt_t qfmt)
 {
     char **nodes;
@@ -386,10 +386,10 @@ list_nodes(genders_t gp, char *query, char *excludequery, fmt_t qfmt)
 
     if (excludequery) {
         genders_nodelist_clear(gp, nodes);
-      
+
         if ((count = genders_query(gp, nodes, len, excludequery)) < 0)
             _gend_error_exit(gp, excludequery);
-    
+
         /* Do not check return code for == 0, node may not exist in hostlist */
         for (i = 0; i < count; i++)
             hostlist_delete(hl, nodes[i]);
@@ -405,7 +405,7 @@ list_nodes(genders_t gp, char *query, char *excludequery, fmt_t qfmt)
     hostlist_destroy(hl);
 }
 
-static int 
+static int
 test_attr(genders_t gp, char *node, char *attr, int vopt)
 {
     char *val = NULL;
@@ -414,7 +414,7 @@ test_attr(genders_t gp, char *node, char *attr, int vopt)
 
     if ((wantval = strchr(attr, '=')))  /* attr can actually be "attr=val" */
         *wantval++ ='\0';
-   
+
     if (vopt || wantval)
         val = _val_create(gp); /* full of nulls initially */
 
@@ -432,7 +432,7 @@ test_attr(genders_t gp, char *node, char *attr, int vopt)
     return res;
 }
 
-static int 
+static int
 test_query(genders_t gp, char *node, char *query)
 {
     int res;
@@ -450,7 +450,7 @@ list_attr_val(genders_t gp, char *attr, int Uopt)
     char *val;
     int maxvallen, nlen, ncount, i, ret;
     unsigned int val_count = 0;
-    
+
     /* achu: There is currently no library operation that offers
      * anything to easily access this information.  So we have to
      * iterate to do it.
@@ -473,10 +473,10 @@ list_attr_val(genders_t gp, char *attr, int Uopt)
 
     for (i = 0; i < ncount; i++) {
         memset(val, '\0', maxvallen + 1);
-        if ((ret = genders_testattr(gp, 
+        if ((ret = genders_testattr(gp,
                                     nodes[i],
-                                    attr, 
-                                    val, 
+                                    attr,
+                                    val,
                                     maxvallen + 1)) < 0)
             _gend_error_exit(gp, "genders_testattr");
         if (ret && strlen(val)) {
@@ -499,7 +499,7 @@ list_attr_val(genders_t gp, char *attr, int Uopt)
             }
         }
     }
-    
+
     for (i = 0; i < val_count; i++) {
         printf("%s\n", myvallist[i]);
     }
@@ -511,7 +511,7 @@ list_attr_val(genders_t gp, char *attr, int Uopt)
     free(val);
 }
 
-static void 
+static void
 usage(void)
 {
     fprintf(stderr,
@@ -519,7 +519,7 @@ usage(void)
         "or     nodeattr [-f genders] [-q|-c|-n|-s] -A\n"
         "or     nodeattr [-f genders] [-v] [node] attr[=val]\n"
         "or     nodeattr [-f genders] -Q [node] query\n"
-        "or     nodeattr [-f genders] -V [-U] attr\n"   
+        "or     nodeattr [-f genders] -V [-U] attr\n"
         "or     nodeattr [-f genders] -l [node]\n"
         "or     nodeattr [-f genders] -k\n"
         "or     nodeattr [-f genders] -d genders\n"
@@ -608,7 +608,7 @@ _diff(genders_t gh, genders_t dgh, char *filename, char *dfilename)
             errcount++;
         }
     }
-    
+
     /* Test #3: For each node, are the attributes and values identical */
 
     if ((maxvals = genders_vallist_create(gh, &vals)) < 0)
@@ -628,7 +628,7 @@ _diff(genders_t gh, genders_t dgh, char *filename, char *dfilename)
     for (i = 0; i < numnodes; i++) {
 
         /* Don't bother if the node doesn't exist, this issue has been
-         * output already 
+         * output already
          */
         if ((rv = genders_isnode(dgh, nodes[i])) < 0)
             _gend_error_exit(dgh, "genders_isnode");
@@ -648,15 +648,15 @@ _diff(genders_t gh, genders_t dgh, char *filename, char *dfilename)
         if (genders_vallist_clear(dgh, dvals) < 0)
             _gend_error_exit(dgh, "genders_vallist_clear");
 
-        if ((numattrs = genders_getattr(gh, 
-                                        attrs, 
-                                        vals, 
-                                        maxattrs, 
+        if ((numattrs = genders_getattr(gh,
+                                        attrs,
+                                        vals,
+                                        maxattrs,
                                         nodes[i])) < 0)
           _gend_error_exit(gh, "genders_getattr");
-        
+
         for (j = 0; j < numattrs; j++) {
-          
+
             /* Don't bother if the attribute doesn't exist, this issue
              * has been output already
              */
@@ -667,17 +667,17 @@ _diff(genders_t gh, genders_t dgh, char *filename, char *dfilename)
                 continue;
 
             memset(dvalbuf, '\0', dmaxvallen + 1);
-          
-            if ((rv = genders_testattr(dgh, 
-                                       nodes[i], 
-                                       attrs[j], 
-                                       dvalbuf, 
+
+            if ((rv = genders_testattr(dgh,
+                                       nodes[i],
+                                       attrs[j],
+                                       dvalbuf,
                                        dmaxvallen + 1)) < 0)
                 _gend_error_exit(dgh, "genders_testattr");
 
             if (!rv) {
                 fprintf(stderr, "%s: Node \"%s\" does not "
-                        "contain attribute \"%s\"\n", 
+                        "contain attribute \"%s\"\n",
                         dfilename, nodes[i], attrs[j]);
                 errcount++;
                 continue;
@@ -714,13 +714,13 @@ _diff(genders_t gh, genders_t dgh, char *filename, char *dfilename)
          * case.  Only for existence of attributes.
          */
 
-        if ((dnumattrs = genders_getattr(dgh, 
-                                         dattrs, 
-                                         dvals, 
-                                         dmaxattrs, 
+        if ((dnumattrs = genders_getattr(dgh,
+                                         dattrs,
+                                         dvals,
+                                         dmaxattrs,
                                          nodes[i])) < 0)
           _gend_error_exit(dgh, "genders_getattr");
-        
+
         for (j = 0; j < dnumattrs; j++) {
 
             /* Don't bother if the attribute doesn't exist, this issue
@@ -732,22 +732,22 @@ _diff(genders_t gh, genders_t dgh, char *filename, char *dfilename)
             if (!rv)
                 continue;
 
-            if ((rv = genders_testattr(gh, 
-                                       nodes[i], 
-                                       dattrs[j], 
+            if ((rv = genders_testattr(gh,
+                                       nodes[i],
+                                       dattrs[j],
                                        NULL,
                                        0)) < 0)
                 _gend_error_exit(gh, "genders_testattr");
-            
+
             if (!rv) {
                 if (strlen(dvals[j])) {
                     fprintf(stderr, "%s: Node \"%s\" contains "
-                            "an additional attribute value pair \"%s=%s\"\n", 
+                            "an additional attribute value pair \"%s=%s\"\n",
                             dfilename, nodes[i], dattrs[j], dvals[j]);
                 }
                 else {
                     fprintf(stderr, "%s: Node \"%s\" contains "
-                            "an additional attribute \"%s\"\n", 
+                            "an additional attribute \"%s\"\n",
                             dfilename, nodes[i], dattrs[j]);
                 }
                 errcount++;
@@ -766,7 +766,7 @@ _diff(genders_t gh, genders_t dgh, char *filename, char *dfilename)
     return errcount;
 }
 
-static void 
+static void
 diff_genders(char *filename, char *dfilename)
 {
     genders_t gh, dgh;
@@ -782,10 +782,10 @@ diff_genders(char *filename, char *dfilename)
         fprintf(stderr, "nodeattr: out of memory\n");
         exit(1);
     }
-    
+
     if (genders_load_data(gh, filename) < 0)
         _gend_error_exit(gh, filename);
-    
+
     if (genders_load_data(dgh, dfilename) < 0)
         _gend_error_exit(dgh, dfilename);
 
@@ -854,7 +854,7 @@ expand(genders_t gp)
 
         if ((attrscount = genders_getattr(gp, attrs, vals, attrslen, node)) < 0)
             _gend_error_exit(gp, "genders_getattr");
-        
+
         printf("%s", node);
         if (attrscount) {
             unsigned int numspace = maxnodenamelen - strlen(node);
@@ -868,7 +868,7 @@ expand(genders_t gp)
                 printf(",");
 
             if (strlen(vals[j]))
-                printf("%s=%s", attrs[j], vals[j]); 
+                printf("%s=%s", attrs[j], vals[j]);
             else
                 printf("%s", attrs[j]);
         }
@@ -921,7 +921,7 @@ _hash_attrval(hash_t hattr, char *node, char *attr, char *val)
     struct hosts_data *hd = NULL;
     char *hashkey = NULL;
     int keylen, attrlen, vallen;
-    
+
     assert(hattr && node && attr && val);
 
     attrlen = strlen(attr);
@@ -934,7 +934,7 @@ _hash_attrval(hash_t hattr, char *node, char *attr, char *val)
 
     /* for NUL char */
     keylen++;
-    
+
     if (!(hashkey = (char *)malloc(keylen))) {
         fprintf(stderr, "malloc: %s\n", strerror(errno));
         exit(1);
@@ -971,7 +971,7 @@ _hash_attrval(hash_t hattr, char *node, char *attr, char *val)
     }
 }
 
-static void 
+static void
 list_attrs(genders_t gp, char *node)
 {
     char **attrs, **vals;
@@ -1011,7 +1011,7 @@ list_attrs(genders_t gp, char *node)
                 _hash_attrval(hattrval, anode, attrs[i], vals[i]);
             free(anode);
         }
-        
+
         if (hash_for_each(hattrval, _print_key, NULL) < 0) {
             fprintf(stderr, "hash_for_each: %s\n", strerror(errno));
             exit(1);
@@ -1061,12 +1061,12 @@ _hash_hostrange(void *data, const void *key, void *arg)
             fprintf(stderr, "malloc: %s\n", strerror(errno));
             exit(1);
         }
-        
+
         if (!(al->hostrange = strdup(hostrange))) {
             fprintf(stderr, "strdup: %s\n", strerror(errno));
             exit(1);
         }
-        
+
         if (!(al->l = list_create(NULL))) {
             fprintf(stderr, "list_create: %s\n", strerror(errno));
             exit(1);
@@ -1135,14 +1135,14 @@ _output_hostrange(void *x, void *arg)
     for (i = 0; i < numspace; i++)
         printf(" ");
     printf(" ");
-    
+
     lcount = list_count(al->l);
 
     if (!(litr = list_iterator_create(al->l))) {
         fprintf(stderr, "list_iterator_create: %s\n", strerror(errno));
         exit(1);
     }
-    
+
     while ((attrval = list_next(litr))) {
 
         if (!strcmp(attrval, NOATTRSFLAG))
@@ -1197,7 +1197,7 @@ compress(genders_t gp)
      * types, b/c we are keying off attr=val pairs, not just the
      * attribute name.
      */
-    if (!(hattr = hash_create((numattrs + 1)*4, 
+    if (!(hattr = hash_create((numattrs + 1)*4,
                           (hash_key_f)hash_key_string,
                           (hash_cmp_f)strcmp,
                           _hosts_data_del))) {
@@ -1231,14 +1231,14 @@ compress(genders_t gp)
             _hash_attrval(hattr, nodes[i], NOATTRSFLAG, "");
             continue;
         }
-        
+
         for (j = 0 ; j < attrscount; j++)
             _hash_attrval(hattr, nodes[i], attrs[j], vals[j]);
     }
 
     /* Now, find all the common attributes for a particular hostrange */
 
-    if (!(hrange = hash_create(numnodes, 
+    if (!(hrange = hash_create(numnodes,
                               (hash_key_f)hash_key_string,
                               (hash_cmp_f)strcmp,
                               _attr_list_del))) {
@@ -1356,7 +1356,7 @@ _flatten_attrsvals(genders_t gp, const char *node, char **attrs, char **vals,
         if (*vals[i]) {
             *(avstring + attrlen) = '=';
             memcpy(avstring + attrlen + 1, vals[i], strlen(vals[i]) + 1);
-        } 
+        }
 
         if (!list_append(avlist, avstring)) {
             fprintf(stderr, "list_insert: %s\n", strerror(errno));
@@ -1389,7 +1389,7 @@ _flatten_attrsvals(genders_t gp, const char *node, char **attrs, char **vals,
     else
         *output_buffer = '\0';
 
-    return(0); 
+    return(0);
 
     cleanup:
     if (avlist)
@@ -1409,13 +1409,13 @@ compress_hosts(genders_t gp)
     char **attrs, **vals;
     int attrslen, valslen;
     int attrscount;
-    int numattrs;  
+    int numattrs;
     int nodeslen;
     int nodescount;
-    int numnodes; 
+    int numnodes;
     int maxattrsvalslen;
-    hash_t hattr = NULL; 
-    hash_t hrange = NULL; 
+    hash_t hattr = NULL;
+    hash_t hrange = NULL;
     List hlist = NULL;
     struct store_hostrange_data shd;
     int i;
@@ -1436,7 +1436,7 @@ compress_hosts(genders_t gp)
 
     if ((attrslen = genders_attrlist_create(gp, &attrs)) < 0)
         _gend_error_exit(gp, "genders_attrlist_create");
-    
+
     if ((valslen = genders_vallist_create(gp, &vals)) < 0)
         _gend_error_exit(gp, "genders_vallist_create");
 
@@ -1492,7 +1492,7 @@ compress_hosts(genders_t gp)
                                     attrsvals) < 0)
                     _gend_error_exit(gp, "_flatten_attrsvals");
                 _hash_allattrvals(hattr, nodes[i], attrsvals);
-            } else 
+            } else
                 _hash_allattrvals(hattr, nodes[i], NOATTRSFLAG);
     }
 
@@ -1544,10 +1544,10 @@ compress_hosts(genders_t gp)
  ** Utility functions
  **/
 
-static int 
+static int
 _gend_error_exit(genders_t gp, char *msg)
 {
-    fprintf(stderr, "nodeattr: %s: %s\n", 
+    fprintf(stderr, "nodeattr: %s: %s\n",
         msg, genders_strerror(genders_errnum(gp)));
     if (genders_errnum(gp) == GENDERS_ERR_PARSE) {
 #if HAVE_GETOPT_LONG
@@ -1584,7 +1584,7 @@ _rangestr(hostlist_t hl, fmt_t qfmt)
      */
     if (qfmt == FMT_HOSTLIST) {
         while (hostlist_ranged_string(hl, size, str) < 0) {
-            free(str); 
+            free(str);
             size += size;
             str = (char *)_safe_malloc(size);
         }
@@ -1593,7 +1593,7 @@ _rangestr(hostlist_t hl, fmt_t qfmt)
         char *p;
 
         while (hostlist_deranged_string(hl, size, str) < 0) {
-            free(str); 
+            free(str);
             size += size;
             str = (char *)_safe_malloc(size);
         }
@@ -1612,7 +1612,7 @@ _val_create(genders_t gp)
     int maxvallen;
     char *val;
 
-    if ((maxvallen = genders_getmaxvallen(gp)) < 0) 
+    if ((maxvallen = genders_getmaxvallen(gp)) < 0)
         _gend_error_exit(gp, "genders_getmaxvallen");
     val = (char *)_safe_malloc(maxvallen + 1);
 
@@ -1627,7 +1627,7 @@ _node_create(genders_t gp)
     int maxnodelen;
     char *node;
 
-    if ((maxnodelen = genders_getmaxnodelen(gp)) < 0) 
+    if ((maxnodelen = genders_getmaxnodelen(gp)) < 0)
         _gend_error_exit(gp, "genders_getmaxnodelen");
     node = (char *)_safe_malloc(maxnodelen + 1);
     return node;
@@ -1640,7 +1640,7 @@ _attr_create(genders_t gp)
     int maxattrlen;
     char *attr;
 
-    if ((maxattrlen = genders_getmaxattrlen(gp)) < 0) 
+    if ((maxattrlen = genders_getmaxattrlen(gp)) < 0)
         _gend_error_exit(gp, "genders_getmaxattrlen");
     attr = (char *)_safe_malloc(maxattrlen + 1);
     return attr;
@@ -1655,13 +1655,13 @@ _to_gendname(genders_t gp, char *val)
     int len;
     char *node = NULL;
 
-    if ((len = genders_nodelist_create(gp, &nodes)) < 0) 
+    if ((len = genders_nodelist_create(gp, &nodes)) < 0)
         _gend_error_exit(gp, "genders_nodelist_create");
 
     if ((count = genders_getnodes(gp, nodes, len, "altname", val)) < 0) {
         genders_nodelist_destroy(gp, nodes);
         _gend_error_exit(gp, val);
-    } 
+    }
     if (count > 1)
         fprintf(stderr, "nodeattr: altname=%s appears more than once!\n", val);
 

--- a/src/testsuite/libgenders/genders_test.c
+++ b/src/testsuite/libgenders/genders_test.c
@@ -49,7 +49,7 @@ static int functionality_tests = 0;
 static void
 _usage(void)
 {
-  fprintf(stderr, 
+  fprintf(stderr,
 	  "Usage: genders_test [OPTIONS]\n"
 	  "-h        output usage\n"
 	  "-v        verbose output (can be used multiple times)\n"
@@ -60,7 +60,7 @@ _usage(void)
   exit(1);
 }
 
-static void 
+static void
 _cmdline_parse(int argc, char **argv)
 {
   int c;
@@ -100,7 +100,7 @@ _corner_case(GendersCornerCaseFunc func, char *funcname)
   if (verbose > 2)
     {
       fprintf(stderr, "***************************************************\n");
-      fprintf(stderr, "* Testing \"%s\" corner cases\n", funcname);                
+      fprintf(stderr, "* Testing \"%s\" corner cases\n", funcname);
       fprintf(stderr, "***************************************************\n");
     }
 
@@ -118,7 +118,7 @@ static int
 _test_corner_cases(void)
 {
   int errtotal = 0;
-  
+
   errtotal += _corner_case(genders_handle_create_corner_case, "genders_handle_create");
   errtotal += _corner_case(genders_handle_destroy_corner_case, "genders_handle_destroy");
   errtotal += _corner_case(genders_load_data_corner_case, "genders_load_data");
@@ -147,14 +147,14 @@ _test_corner_cases(void)
   errtotal += _corner_case(genders_getnodes_corner_case, "genders_getnodes");
   errtotal += _corner_case(genders_getattr_corner_case, "genders_getattr");
   errtotal += _corner_case(genders_getattr_all_corner_case, "genders_getattr_all");
-  errtotal += _corner_case(genders_testattr_corner_case, "genders_testattr"); 
+  errtotal += _corner_case(genders_testattr_corner_case, "genders_testattr");
   errtotal += _corner_case(genders_testattrval_corner_case, "genders_testattrval");
   errtotal += _corner_case(genders_isnode_corner_case, "genders_isnode");
   errtotal += _corner_case(genders_isattr_corner_case, "genders_isattr");
   errtotal += _corner_case(genders_isattrval_corner_case, "genders_isattrval");
   errtotal += _corner_case(genders_index_attrvals_corner_case, "genders_index_attrvals");
   errtotal += _corner_case(genders_query_corner_case, "genders_query");
-  errtotal += _corner_case(genders_testquery_corner_case, "genders_testquery"); 
+  errtotal += _corner_case(genders_testquery_corner_case, "genders_testquery");
   errtotal += _corner_case(genders_parse_corner_case, "genders_parse");
   errtotal += _corner_case(genders_set_errnum_corner_case, "genders_set_errnum");
   errtotal += _corner_case(genders_copy_corner_case, "genders_copy");
@@ -170,7 +170,7 @@ _functionality(GendersCornerCaseFunc func, char *funcname)
   if (verbose > 2)
     {
       fprintf(stderr, "***************************************************\n");
-      fprintf(stderr, "* Testing \"%s\" functionality\n", funcname);                
+      fprintf(stderr, "* Testing \"%s\" functionality\n", funcname);
       fprintf(stderr, "***************************************************\n");
     }
 
@@ -188,7 +188,7 @@ static int
 _test_functionality(void)
 {
   int errtotal = 0;
-  
+
   errtotal += _functionality(genders_handle_create_functionality, "genders_handle_create");
   errtotal += _functionality(genders_handle_destroy_functionality, "genders_handle_destroy");
   errtotal += _functionality(genders_load_data_functionality, "genders_load_data");
@@ -217,7 +217,7 @@ _test_functionality(void)
   errtotal += _functionality(genders_getnodes_functionality, "genders_getnodes");
   errtotal += _functionality(genders_getattr_functionality, "genders_getattr");
   errtotal += _functionality(genders_getattr_all_functionality, "genders_getattr_all");
-  errtotal += _functionality(genders_testattr_functionality, "genders_testattr"); 
+  errtotal += _functionality(genders_testattr_functionality, "genders_testattr");
   errtotal += _functionality(genders_testattrval_functionality, "genders_testattrval");
   errtotal += _functionality(genders_isnode_functionality, "genders_isnode");
   errtotal += _functionality(genders_isattr_functionality, "genders_isattr");
@@ -247,7 +247,7 @@ main(int argc, char **argv)
 	fprintf(stderr, "Total Corner Case Failures: %d\n", errcount);
       errtotal += errcount;
     }
-  
+
   if (all_tests || functionality_tests)
     {
       errcount = _test_functionality();
@@ -257,8 +257,8 @@ main(int argc, char **argv)
       errtotal += errcount;
     }
 
-  if (all_tests 
-      || corner_case_tests 
+  if (all_tests
+      || corner_case_tests
       || functionality_tests)
     {
       if ((verbose && errtotal)

--- a/src/testsuite/libgenders/genders_test_corner_case.c
+++ b/src/testsuite/libgenders/genders_test_corner_case.c
@@ -51,8 +51,8 @@
 #define MAXHOSTNAMELEN    64
 #endif /* MAXHOSTNAMELEN */
 
-static genders_t 
-genders_unloaded_handle(void) 
+static genders_t
+genders_unloaded_handle(void)
 {
   genders_t handle = genders_handle_create();
   if (!handle)
@@ -60,7 +60,7 @@ genders_unloaded_handle(void)
   return handle;
 }
 
-static genders_t 
+static genders_t
 genders_destroyed_unloaded_handle(void)
 {
   genders_t handle = genders_handle_create();
@@ -72,8 +72,8 @@ genders_destroyed_unloaded_handle(void)
   return handle;
 }
 
-static genders_t 
-genders_loaded_handle(void) 
+static genders_t
+genders_loaded_handle(void)
 {
   genders_t handle = genders_handle_create();
   if (!handle)
@@ -83,7 +83,7 @@ genders_loaded_handle(void)
   return handle;
 }
 
-static genders_t 
+static genders_t
 genders_destroyed_loaded_handle(void)
 {
   genders_t handle = genders_handle_create();
@@ -175,7 +175,7 @@ genders_handle_destroy_corner_case(int verbose)
   int errcount = 0;
   genders_handle_destroy_corner_case_t *tests = &genders_handle_destroy_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       int return_value, errnum;
@@ -221,7 +221,7 @@ genders_load_data_corner_case(int verbose)
       }
   }
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *filename;
@@ -254,14 +254,14 @@ genders_errnum_corner_case(int verbose)
   int errcount = 0;
   genders_errnum_corner_case_t *tests = &genders_errnum_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       int err, return_value;
 
       handle = genders_handle_get(tests[i].param1);
       return_value = genders_errnum(handle);
- 
+
       err = genders_return_value_check("genders_errnum",
 				       tests[i].num,
 				       tests[i].expected_return_value,
@@ -284,7 +284,7 @@ genders_strerror_corner_case(int verbose)
   int errcount = 0;
   genders_strerror_corner_case_t *tests = &genders_strerror_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *pointer;
@@ -294,7 +294,7 @@ genders_strerror_corner_case(int verbose)
       handle = genders_handle_get(tests[i].param1);
       expected_pointer = genders_errormsg(handle);
       pointer = genders_strerror(tests[i].expected_errnum_string);
- 
+
       err = genders_pointer_check("genders_errormsg",
 				  tests[i].num,
 				  expected_pointer,
@@ -318,7 +318,7 @@ genders_errormsg_corner_case(int verbose)
   int errcount = 0;
   genders_errormsg_corner_case_t *tests = &genders_errormsg_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *pointer;
@@ -328,7 +328,7 @@ genders_errormsg_corner_case(int verbose)
       handle = genders_handle_get(tests[i].param1);
       expected_pointer = genders_strerror(tests[i].expected_errnum_string);
       pointer = genders_errormsg(handle);
- 
+
       err = genders_pointer_check("genders_errormsg",
 				  tests[i].num,
 				  expected_pointer,
@@ -341,7 +341,7 @@ genders_errormsg_corner_case(int verbose)
       genders_handle_cleanup(handle);
       i++;
     }
-  
+
   return errcount;
 }
 
@@ -358,8 +358,8 @@ genders_perror_corner_case(int verbose)
     genders_err_exit("dup: %s", strerror(errno));
   if ((dev_null = open(_PATH_DEVNULL, O_APPEND)) < 0)
     genders_err_exit("open: %s: %s", _PATH_DEVNULL, strerror(errno));
-  
-  while (!(tests[i].num < 0)) 
+
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       int err, errnum;
@@ -396,7 +396,7 @@ genders_get_flags_corner_case(int verbose)
   int errcount = 0;
   genders_get_flags_corner_case_t *tests = &genders_get_flags_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       unsigned int flags;
@@ -431,7 +431,7 @@ genders_set_flags_corner_case(int verbose)
   int errcount = 0;
   genders_set_flags_corner_case_t *tests = &genders_set_flags_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       unsigned int flags;
@@ -459,7 +459,7 @@ genders_set_flags_corner_case(int verbose)
 }
 
 static int
-_genders_getfunc_corner_case(GendersGetFunc func, 
+_genders_getfunc_corner_case(GendersGetFunc func,
 			     char *funcname,
 			     int num,
 			     genders_handle_type_t param1,
@@ -496,7 +496,7 @@ genders_getnumnodes_corner_case(int verbose)
   int errcount = 0;
   genders_getnumnodes_corner_case_t *tests = &genders_getnumnodes_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_getfunc_corner_case(genders_getnumnodes,
 					       "genders_getnumnodes",
@@ -518,7 +518,7 @@ genders_getnumattrs_corner_case(int verbose)
   int errcount = 0;
   genders_getnumattrs_corner_case_t *tests = &genders_getnumattrs_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_getfunc_corner_case(genders_getnumattrs,
 					       "genders_getnumattrs",
@@ -540,7 +540,7 @@ genders_getmaxattrs_corner_case(int verbose)
   int errcount = 0;
   genders_getmaxattrs_corner_case_t *tests = &genders_getmaxattrs_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_getfunc_corner_case(genders_getmaxattrs,
 					       "genders_getmaxattrs",
@@ -583,7 +583,7 @@ genders_getmaxnodelen_corner_case(int verbose)
       tests[3].expected_return_value = strlen(buffer);
   }
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_getfunc_corner_case(genders_getmaxnodelen,
 					       "genders_getmaxnodelen",
@@ -605,7 +605,7 @@ genders_getmaxattrlen_corner_case(int verbose)
   int errcount = 0;
   genders_getmaxattrlen_corner_case_t *tests = &genders_getmaxattrlen_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_getfunc_corner_case(genders_getmaxattrlen,
 					       "genders_getmaxattrlen",
@@ -627,7 +627,7 @@ genders_getmaxvallen_corner_case(int verbose)
   int errcount = 0;
   genders_getmaxvallen_corner_case_t *tests = &genders_getmaxvallen_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_getfunc_corner_case(genders_getmaxvallen,
 					       "genders_getmaxvallen",
@@ -664,7 +664,7 @@ _genders_list_create_corner_case(GendersListCreateFunc funccreate,
   listptr = (param2 == GENDERS_POINTER_NULL) ? NULL : &list;
   return_value = funccreate(handle, listptr);
   errnum = genders_errnum(handle);
-      
+
   err = genders_return_value_errnum_check(funcname,
 					  num,
 					  expected_return_value,
@@ -722,7 +722,7 @@ _genders_list_clear_corner_case(GendersListCreateFunc funccreate,
   handle = genders_handle_get(param1);
   return_value = funcclear(handle, list);
   errnum = genders_errnum(handle);
-      
+
   err = genders_return_value_errnum_check(funcname,
 					  num,
 					  expected_return_value,
@@ -740,7 +740,7 @@ _genders_list_clear_corner_case(GendersListCreateFunc funccreate,
 	genders_err_exit("genders_handle_destroy: %s", genders_errormsg(gh));
     }
   genders_handle_cleanup(handle);
-  
+
   return err;
 }
 
@@ -778,7 +778,7 @@ _genders_list_destroy_corner_case(GendersListCreateFunc funccreate,
   handle = genders_handle_get(param1);
   return_value = funcdestroy(handle, list);
   errnum = genders_errnum(handle);
-      
+
   err = genders_return_value_errnum_check(funcname,
 					  num,
 					  expected_return_value,
@@ -810,7 +810,7 @@ genders_nodelist_create_corner_case(int verbose)
   int errcount = 0;
   genders_nodelist_create_corner_case_t *tests = &genders_nodelist_create_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_create_corner_case(genders_nodelist_create,
 						   genders_nodelist_destroy,
@@ -834,7 +834,7 @@ genders_nodelist_clear_corner_case(int verbose)
   int errcount = 0;
   genders_nodelist_clear_corner_case_t *tests = &genders_nodelist_clear_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_clear_corner_case(genders_nodelist_create,
 						  genders_nodelist_clear,
@@ -859,7 +859,7 @@ genders_nodelist_destroy_corner_case(int verbose)
   int errcount = 0;
   genders_nodelist_destroy_corner_case_t *tests = &genders_nodelist_destroy_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_destroy_corner_case(genders_nodelist_create,
 						    genders_nodelist_destroy,
@@ -883,7 +883,7 @@ genders_attrlist_create_corner_case(int verbose)
   int errcount = 0;
   genders_attrlist_create_corner_case_t *tests = &genders_attrlist_create_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_create_corner_case(genders_attrlist_create,
 						   genders_attrlist_destroy,
@@ -907,7 +907,7 @@ genders_attrlist_clear_corner_case(int verbose)
   int errcount = 0;
   genders_attrlist_clear_corner_case_t *tests = &genders_attrlist_clear_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_clear_corner_case(genders_attrlist_create,
 						  genders_attrlist_clear,
@@ -932,7 +932,7 @@ genders_attrlist_destroy_corner_case(int verbose)
   int errcount = 0;
   genders_attrlist_destroy_corner_case_t *tests = &genders_attrlist_destroy_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_destroy_corner_case(genders_attrlist_create,
 						    genders_attrlist_destroy,
@@ -956,7 +956,7 @@ genders_vallist_create_corner_case(int verbose)
   int errcount = 0;
   genders_vallist_create_corner_case_t *tests = &genders_vallist_create_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_create_corner_case(genders_vallist_create,
 						   genders_vallist_destroy,
@@ -980,7 +980,7 @@ genders_vallist_clear_corner_case(int verbose)
   int errcount = 0;
   genders_vallist_clear_corner_case_t *tests = &genders_vallist_clear_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_clear_corner_case(genders_vallist_create,
 						  genders_vallist_clear,
@@ -1005,7 +1005,7 @@ genders_vallist_destroy_corner_case(int verbose)
   int errcount = 0;
   genders_vallist_destroy_corner_case_t *tests = &genders_vallist_destroy_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       errcount += _genders_list_destroy_corner_case(genders_vallist_create,
 						    genders_vallist_destroy,
@@ -1029,7 +1029,7 @@ genders_getnodename_corner_case(int verbose)
   int errcount = 0;
   genders_getnodename_corner_case_t *tests = &genders_getnodename_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       int return_value, errnum, len;
@@ -1072,7 +1072,7 @@ genders_getnodes_corner_case(int verbose)
   if ((list_len = genders_nodelist_create(gh, &list)) < 0)
     genders_err_exit("genders_nodelist_create: %s", genders_errormsg(gh));
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       int return_value, errnum, len;
@@ -1138,7 +1138,7 @@ genders_getattr_corner_case(int verbose)
   if (genders_vallist_create(gh, &vallist) < 0)
     genders_err_exit("genders_vallist_create: %s", genders_errormsg(gh));
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char **attrlistptr;
@@ -1198,7 +1198,7 @@ genders_getattr_all_corner_case(int verbose)
   if ((attrlist_len = genders_attrlist_create(gh, &attrlist)) < 0)
     genders_err_exit("genders_attrlist_create: %s", genders_errormsg(gh));
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char **attrlistptr;
@@ -1247,7 +1247,7 @@ genders_testattr_corner_case(int verbose)
   if (!(valbuf = (char *)malloc(maxvallen + 1)))
     genders_err_exit("malloc: %s", strerror(errno));
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *nodeptr, *attrptr, *valptr;
@@ -1301,7 +1301,7 @@ genders_testattrval_corner_case(int verbose)
   int errcount = 0;
   genders_testattrval_corner_case_t *tests = &genders_testattrval_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *nodeptr, *attrptr, *valptr;
@@ -1356,7 +1356,7 @@ genders_isnode_corner_case(int verbose)
   int errcount = 0;
   genders_isnode_corner_case_t *tests = &genders_isnode_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *nodeptr;
@@ -1370,7 +1370,7 @@ genders_isnode_corner_case(int verbose)
 	nodeptr = "";
       else
 	nodeptr = genders_database_corner_case.data->node;
-      
+
       return_value = genders_isnode(handle, nodeptr);
       errnum = genders_errnum(handle);
 
@@ -1397,7 +1397,7 @@ genders_isattr_corner_case(int verbose)
   int errcount = 0;
   genders_isattr_corner_case_t *tests = &genders_isattr_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *attrptr;
@@ -1438,7 +1438,7 @@ genders_isattrval_corner_case(int verbose)
   int errcount = 0;
   genders_isattrval_corner_case_t *tests = &genders_isattrval_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *attrptr, *valptr;
@@ -1486,7 +1486,7 @@ genders_index_attrvals_corner_case(int verbose)
   int errcount = 0;
   genders_index_attrvals_corner_case_t *tests = &genders_index_attrvals_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *attrptr;
@@ -1534,7 +1534,7 @@ genders_query_corner_case(int verbose)
   if ((list_len = genders_nodelist_create(gh, &list)) < 0)
     genders_err_exit("genders_nodelist_create: %s", genders_errormsg(gh));
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       int return_value, errnum, len;
@@ -1581,7 +1581,7 @@ genders_testquery_corner_case(int verbose)
   int errcount = 0;
   genders_testquery_corner_case_t *tests = &genders_testquery_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *nodeptr, *queryptr;
@@ -1605,7 +1605,7 @@ genders_testquery_corner_case(int verbose)
 
       return_value = genders_testquery(handle, nodeptr, queryptr);
       errnum = genders_errnum(handle);
-      
+
       errcount += genders_return_value_errnum_check("genders_testquery",
 						    tests[i].num,
 						    tests[i].expected_return_value,
@@ -1614,7 +1614,7 @@ genders_testquery_corner_case(int verbose)
 						    errnum,
 						    NULL,
 						    verbose);
-      
+
       genders_handle_cleanup(handle);
       i++;
     }
@@ -1664,7 +1664,7 @@ genders_parse_corner_case(int verbose)
   if ((dev_null = open(_PATH_DEVNULL, O_APPEND)) < 0)
     genders_err_exit("open: %s: %s", _PATH_DEVNULL, strerror(errno));
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       char *filename;
@@ -1706,7 +1706,7 @@ genders_set_errnum_corner_case(int verbose)
   int errcount = 0;
   genders_set_errnum_corner_case_t *tests = &genders_set_errnum_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       int err, errnum;
@@ -1714,7 +1714,7 @@ genders_set_errnum_corner_case(int verbose)
       handle = genders_handle_get(tests[i].param1);
       genders_set_errnum(handle, tests[i].param2);
       errnum = genders_errnum(handle);
- 
+
       err = genders_errnum_check("genders_set_errnum",
 				 tests[i].num,
 				 tests[i].expected_errnum,
@@ -1737,7 +1737,7 @@ genders_copy_corner_case(int verbose)
   int errcount = 0;
   genders_copy_corner_case_t *tests = &genders_copy_corner_case_tests[0];
 
-  while (!(tests[i].num < 0)) 
+  while (!(tests[i].num < 0))
     {
       genders_t handle;
       genders_t return_value;
@@ -1746,7 +1746,7 @@ genders_copy_corner_case(int verbose)
       handle = genders_handle_get(tests[i].param1);
       return_value = genders_copy(handle);
       errnum = genders_errnum(handle);
- 
+
       errcount += genders_return_value_pointer_errnum_check("genders_copy",
 							    tests[i].num,
 							    tests[i].expected_return_value,
@@ -1755,7 +1755,7 @@ genders_copy_corner_case(int verbose)
 							    errnum,
 							    NULL,
 							    verbose);
-      
+
       genders_handle_cleanup(handle);
       i++;
     }

--- a/src/testsuite/libgenders/genders_test_corner_case.h
+++ b/src/testsuite/libgenders/genders_test_corner_case.h
@@ -62,7 +62,7 @@ typedef struct {
   int expected_errnum;
 } genders_handle_pointer_length_corner_case_t;
 
-typedef genders_handle_corner_case_t genders_handle_destroy_corner_case_t; 
+typedef genders_handle_corner_case_t genders_handle_destroy_corner_case_t;
 
 typedef struct {
   int num;
@@ -70,7 +70,7 @@ typedef struct {
   genders_filename_type_t param2;
   int expected_return_value;
   int expected_errnum;
-} genders_load_data_corner_case_t; 
+} genders_load_data_corner_case_t;
 
 typedef struct {
   int num;
@@ -102,7 +102,7 @@ typedef struct {
   genders_flag_type_t param2;
   int expected_return_value;
   int expected_errnum;
-} genders_set_flags_corner_case_t; 
+} genders_set_flags_corner_case_t;
 
 typedef genders_handle_corner_case_t genders_getnumnodes_corner_case_t;
 typedef genders_handle_corner_case_t genders_getnumattrs_corner_case_t;

--- a/src/testsuite/libgenders/genders_test_database.c
+++ b/src/testsuite/libgenders/genders_test_database.c
@@ -29,7 +29,7 @@
 
 #include "genders_test_database.h"
 
-genders_parse_error_database_t genders_parse_error_databases[] = 
+genders_parse_error_database_t genders_parse_error_databases[] =
   {
 #if 0
     /* No longer a parse error */
@@ -83,7 +83,7 @@ genders_parse_error_database_t genders_parse_error_databases[] =
     {NULL, -1},
   };
 
-genders_database_data_t genders_database_data_not_exist = 
+genders_database_data_t genders_database_data_not_exist =
   {
     NULL,
     NULL,
@@ -126,7 +126,7 @@ genders_database_t genders_database_not_exist =
     &genders_database_data_not_exist,
   };
 
-genders_database_data_t genders_database_data_corner_case = 
+genders_database_data_t genders_database_data_corner_case =
   {
     "node1",
     "attr1",
@@ -139,7 +139,7 @@ genders_database_data_t genders_database_data_corner_case =
     5,				/* GENDERS_DATABASE_CORNER_CASE_MAXATTRLEN */
     4,				/* GENDERS_DATABASE_CORNER_CASE_MAXVALLEN */
     {"node1", "node2", NULL},
-    2,				
+    2,
     {"attr1", "attr2", NULL},
     2,
     {NULL,    "val2", NULL},
@@ -147,14 +147,14 @@ genders_database_data_t genders_database_data_corner_case =
     {
       {
 	{"attr1", "attr2", NULL},
-	{"", "val2", NULL}, 
-	{NULL, "val2", NULL}, 
+	{"", "val2", NULL},
+	{NULL, "val2", NULL},
 	2,
       },
       {
 	{"attr1", "attr2", NULL},
-	{"", "val2", NULL}, 
-	{NULL, "val2", NULL}, 
+	{"", "val2", NULL},
+	{NULL, "val2", NULL},
 	2,
       },
     },
@@ -188,13 +188,13 @@ genders_database_data_t genders_database_data_corner_case =
     4,
   };
 
-genders_database_t genders_database_corner_case = 
+genders_database_t genders_database_corner_case =
   {
     "testdatabases/genders.corner_case",
     &genders_database_data_corner_case,
   };
 
-genders_database_data_t genders_database_data_base = 
+genders_database_data_t genders_database_data_base =
   {
     "node1",
     "attr1",
@@ -207,7 +207,7 @@ genders_database_data_t genders_database_data_base =
     5,
     4,
     {"node1", "node2", NULL},
-    2,				
+    2,
     {"attr1", "attr2", NULL},
     2,
     {NULL,    "val2", NULL},
@@ -215,14 +215,14 @@ genders_database_data_t genders_database_data_base =
     {
       {
 	{"attr1", "attr2", NULL},
-	{"", "val2", NULL}, 
-	{NULL, "val2", NULL}, 
+	{"", "val2", NULL},
+	{NULL, "val2", NULL},
 	2,
       },
       {
 	{"attr1", "attr2", NULL},
-	{"", "val2", NULL}, 
-	{NULL, "val2", NULL}, 
+	{"", "val2", NULL},
+	{NULL, "val2", NULL},
 	2,
       },
     },
@@ -262,7 +262,7 @@ genders_database_data_t genders_database_data_base =
     5,
   };
 
-genders_database_t genders_database_base = 
+genders_database_t genders_database_base =
   {
     "testdatabases/genders.base",
     &genders_database_data_base,
@@ -442,7 +442,7 @@ genders_database_t genders_database_base_whitespace_between_nodes_and_attrs =
     &genders_database_data_base,
   };
 
-genders_database_data_t genders_database_data_test_1 = 
+genders_database_data_t genders_database_data_test_1 =
   {
     "node1",
     "attr1",
@@ -455,7 +455,7 @@ genders_database_data_t genders_database_data_test_1 =
     5,
     4,
     {"node1", "node2", "node3", "node4", NULL},
-    4,				
+    4,
     {"attr1", "attr2", "attr3", "attr4", NULL},
     4,
     {NULL,    "val2",  NULL,    "val4",  NULL},
@@ -463,26 +463,26 @@ genders_database_data_t genders_database_data_test_1 =
     {
       {
 	{"attr1", "attr2", "attr3", "attr4", NULL},
-	{"", "val2", "", "val4", NULL}, 
-	{NULL, "val2", NULL, "val4", NULL}, 
+	{"", "val2", "", "val4", NULL},
+	{NULL, "val2", NULL, "val4", NULL},
 	4,
       },
       {
 	{"attr1", "attr2", "attr3", "attr4", NULL},
-	{"", "val2", "", "val4", NULL}, 
-	{NULL, "val2", NULL, "val4", NULL}, 
+	{"", "val2", "", "val4", NULL},
+	{NULL, "val2", NULL, "val4", NULL},
 	4,
       },
       {
 	{"attr1", "attr2", "attr3", "attr4", NULL},
-	{"", "val2", "", "val4", NULL}, 
-	{NULL, "val2", NULL, "val4", NULL}, 
+	{"", "val2", "", "val4", NULL},
+	{NULL, "val2", NULL, "val4", NULL},
 	4,
       },
       {
 	{"attr1", "attr2", "attr3", "attr4", NULL},
-	{"", "val2", "", "val4", NULL}, 
-	{NULL, "val2", NULL, "val4", NULL}, 
+	{"", "val2", "", "val4", NULL},
+	{NULL, "val2", NULL, "val4", NULL},
 	4,
       },
     },
@@ -558,7 +558,7 @@ genders_database_t genders_database_test_1_hostrange =
     &genders_database_data_test_1,
   };
 
-genders_database_data_t genders_database_data_test_2 = 
+genders_database_data_t genders_database_data_test_2 =
   {
     "node1",
     "attr1",
@@ -571,38 +571,38 @@ genders_database_data_t genders_database_data_test_2 =
     5,
     4,
     {"node1", "node2", "node3", "node4", NULL},
-    4,				
-    {"attr1", "attr2", "attr3", "attr4", 
+    4,
+    {"attr1", "attr2", "attr3", "attr4",
      "attr5", "attr6", "attr7", "attr8",
      NULL},
     8,
-    {NULL,    "val2",  NULL,    "val4",  
-     NULL,    "val6",  NULL,    "val8",  
+    {NULL,    "val2",  NULL,    "val4",
+     NULL,    "val6",  NULL,    "val8",
      NULL},
     8,
     {
       {
 	{"attr1", "attr2", "attr3", "attr4", NULL},
-	{"", "val2", "", "val4", NULL}, 
-	{NULL, "val2", NULL, "val4", NULL}, 
+	{"", "val2", "", "val4", NULL},
+	{NULL, "val2", NULL, "val4", NULL},
 	4,
       },
       {
 	{"attr5", "attr6", "attr7", "attr8", NULL},
-	{"", "val6", "", "val8", NULL}, 
-	{NULL, "val6", NULL, "val8", NULL}, 
+	{"", "val6", "", "val8", NULL},
+	{NULL, "val6", NULL, "val8", NULL},
 	4,
       },
       {
 	{"attr1", "attr2", "attr3", "attr4", NULL},
-	{"", "val2", "", "val4", NULL}, 
-	{NULL, "val2", NULL, "val4", NULL}, 
+	{"", "val2", "", "val4", NULL},
+	{NULL, "val2", NULL, "val4", NULL},
 	4,
       },
       {
 	{"attr5", "attr6", "attr7", "attr8", NULL},
-	{"", "val6", "", "val8", NULL}, 
-	{NULL, "val6", NULL, "val8", NULL}, 
+	{"", "val6", "", "val8", NULL},
+	{NULL, "val6", NULL, "val8", NULL},
 	4,
       },
     },
@@ -714,7 +714,7 @@ genders_database_t genders_database_test_2_hostrange =
     &genders_database_data_test_2,
   };
 
-genders_database_data_t genders_database_data_test_3 = 
+genders_database_data_t genders_database_data_test_3 =
   {
     "node1",
     "attr1",
@@ -727,42 +727,42 @@ genders_database_data_t genders_database_data_test_3 =
     6,
     5,
     {"node1", "node2", "node3", "node4", NULL},
-    4,				
-    {"attr1",  "attr2",  "attr3",  "attr4", 
+    4,
+    {"attr1",  "attr2",  "attr3",  "attr4",
      "attr5",  "attr6",  "attr7",  "attr8",
-     "attr9",  "attr10", "attr11", "attr12", 
+     "attr9",  "attr10", "attr11", "attr12",
      "attr13", "attr14", "attr15", "attr16",
      NULL},
     16,
-    {NULL,    "val2",  NULL,    "val4",  
-     NULL,    "val6",  NULL,    "val8",  
-     NULL,    "val10",  NULL,    "val12",  
-     NULL,    "val14",  NULL,    "val16",  
+    {NULL,    "val2",  NULL,    "val4",
+     NULL,    "val6",  NULL,    "val8",
+     NULL,    "val10",  NULL,    "val12",
+     NULL,    "val14",  NULL,    "val16",
      NULL},
     16,
     {
       {
 	{"attr1", "attr2", "attr3", "attr4", NULL},
-	{"", "val2", "", "val4", NULL}, 
-	{NULL, "val2", NULL, "val4", NULL}, 
+	{"", "val2", "", "val4", NULL},
+	{NULL, "val2", NULL, "val4", NULL},
 	4,
       },
       {
 	{"attr5", "attr6", "attr7", "attr8", NULL},
-	{"", "val6", "", "val8", NULL}, 
-	{NULL, "val6", NULL, "val8", NULL}, 
+	{"", "val6", "", "val8", NULL},
+	{NULL, "val6", NULL, "val8", NULL},
 	4,
       },
       {
 	{"attr9", "attr10", "attr11", "attr12", NULL},
-	{"", "val10", "", "val12", NULL}, 
-	{NULL, "val10", NULL, "val12", NULL}, 
+	{"", "val10", "", "val12", NULL},
+	{NULL, "val10", NULL, "val12", NULL},
 	4,
       },
       {
 	{"attr13", "attr14", "attr15", "attr16", NULL},
-	{"", "val14", "", "val16", NULL}, 
-	{NULL, "val14", NULL, "val16", NULL}, 
+	{"", "val14", "", "val16", NULL},
+	{NULL, "val14", NULL, "val16", NULL},
 	4,
       },
     },
@@ -934,7 +934,7 @@ genders_database_t genders_database_test_3 =
     &genders_database_data_test_3,
   };
 
-genders_database_data_t genders_database_data_empty = 
+genders_database_data_t genders_database_data_empty =
   {
     NULL,
     NULL,
@@ -977,7 +977,7 @@ genders_database_t genders_database_empty =
     &genders_database_data_empty,
   };
 
-genders_database_data_t genders_database_data_equal_sign_in_value = 
+genders_database_data_t genders_database_data_equal_sign_in_value =
   {
     "node1",
     "attr2",
@@ -998,14 +998,14 @@ genders_database_data_t genders_database_data_equal_sign_in_value =
     {
       {
 	{"attr1", NULL},
-	{"foo=bar", NULL}, 
-	{NULL, NULL}, 
+	{"foo=bar", NULL},
+	{NULL, NULL},
 	1,
       },
       {
 	{"attr1", "attr2", NULL},
-	{"foo=baz", "", NULL}, 
-	{"foo=baz", NULL, NULL}, 
+	{"foo=baz", "", NULL},
+	{"foo=baz", NULL, NULL},
 	2,
       },
     },
@@ -1058,7 +1058,7 @@ genders_database_t genders_database_equal_sign_in_value =
     &genders_database_data_equal_sign_in_value,
   };
 
-genders_database_data_t genders_database_data_nodes_only_one = 
+genders_database_data_t genders_database_data_nodes_only_one =
   {
     "node1",
     NULL,
@@ -1071,7 +1071,7 @@ genders_database_data_t genders_database_data_nodes_only_one =
     0,
     0,
     {"node1", NULL},
-    1,				
+    1,
     {NULL},
     0,
     {NULL},
@@ -1079,8 +1079,8 @@ genders_database_data_t genders_database_data_nodes_only_one =
     {
       {
 	{NULL},
-	{NULL}, 
-	{NULL}, 
+	{NULL},
+	{NULL},
 	0,
       },
     },
@@ -1102,13 +1102,13 @@ genders_database_data_t genders_database_data_nodes_only_one =
     2,
   };
 
-genders_database_t genders_database_nodes_only_one = 
+genders_database_t genders_database_nodes_only_one =
   {
     "testdatabases/genders.nodes_only_one",
     &genders_database_data_nodes_only_one,
   };
 
-genders_database_data_t genders_database_data_nodes_only_many = 
+genders_database_data_t genders_database_data_nodes_only_many =
   {
     "node1",
     NULL,
@@ -1121,7 +1121,7 @@ genders_database_data_t genders_database_data_nodes_only_many =
     0,
     0,
     {"node1", "node2", "node3", "node4", "node5", NULL},
-    5,				
+    5,
     {NULL},
     0,
     {NULL},
@@ -1129,8 +1129,8 @@ genders_database_data_t genders_database_data_nodes_only_many =
     {
       {
 	{NULL},
-	{NULL}, 
-	{NULL}, 
+	{NULL},
+	{NULL},
 	0,
       },
     },
@@ -1152,13 +1152,13 @@ genders_database_data_t genders_database_data_nodes_only_many =
     2,
   };
 
-genders_database_t genders_database_nodes_only_many = 
+genders_database_t genders_database_nodes_only_many =
   {
     "testdatabases/genders.nodes_only_many",
     &genders_database_data_nodes_only_many,
   };
 
-genders_database_data_t genders_database_data_nodes_and_attrs_only = 
+genders_database_data_t genders_database_data_nodes_and_attrs_only =
   {
     "node1",
     "attr1",
@@ -1171,7 +1171,7 @@ genders_database_data_t genders_database_data_nodes_and_attrs_only =
     5,
     0,
     {"node1", "node2", NULL},
-    2,				
+    2,
     {"attr1", "attr2", NULL},
     2,
     {NULL},
@@ -1179,14 +1179,14 @@ genders_database_data_t genders_database_data_nodes_and_attrs_only =
     {
       {
 	{"attr1", "attr2", NULL},
-	{"", "", NULL}, 
-	{NULL, NULL, NULL}, 
+	{"", "", NULL},
+	{NULL, NULL, NULL},
 	2,
       },
       {
 	{"attr1", "attr2", NULL},
-	{"", "", NULL}, 
-	{NULL, NULL, NULL}, 
+	{"", "", NULL},
+	{NULL, NULL, NULL},
 	2,
       },
     },
@@ -1220,25 +1220,25 @@ genders_database_data_t genders_database_data_nodes_and_attrs_only =
     4,
   };
 
-genders_database_t genders_database_nodes_and_attrs_only = 
+genders_database_t genders_database_nodes_and_attrs_only =
   {
     "testdatabases/genders.nodes_and_attrs_only",
     &genders_database_data_nodes_and_attrs_only,
   };
 
-genders_database_t genders_database_nodes_and_attrs_only_comma = 
+genders_database_t genders_database_nodes_and_attrs_only_comma =
   {
     "testdatabases/genders.nodes_and_attrs_only_comma",
     &genders_database_data_nodes_and_attrs_only,
   };
 
-genders_database_t genders_database_nodes_and_attrs_only_hostrange = 
+genders_database_t genders_database_nodes_and_attrs_only_hostrange =
   {
     "testdatabases/genders.nodes_and_attrs_only_hostrange",
     &genders_database_data_nodes_and_attrs_only,
   };
 
-genders_database_data_t genders_database_data_subst_escape_char = 
+genders_database_data_t genders_database_data_subst_escape_char =
   {
     "node1",
     "attr1",
@@ -1251,7 +1251,7 @@ genders_database_data_t genders_database_data_subst_escape_char =
     7,
     4,
     {"node1", "node2", NULL},
-    2,				
+    2,
     {"attr1", "attr2", "escape1", "escape2", "escape3", NULL},
     5,
     {NULL,    "val2", "%t", "%t", "%n", NULL},
@@ -1259,14 +1259,14 @@ genders_database_data_t genders_database_data_subst_escape_char =
     {
       {
 	{"attr1", "attr2", "escape1", "escape2", "escape3", NULL},
-	{"", "val2", "%t", "%t", "%n", NULL}, 
-	{NULL, "val2", "%t", "%t", "%n", NULL}, 
+	{"", "val2", "%t", "%t", "%n", NULL},
+	{NULL, "val2", "%t", "%t", "%n", NULL},
 	5,
       },
       {
 	{"attr1", "attr2", "escape1", "escape2", "escape3", NULL},
-	{"", "val2", "%t", "%t", "%n", NULL}, 
-	{NULL, "val2", "%t", "%t", "%n", NULL}, 
+	{"", "val2", "%t", "%t", "%n", NULL},
+	{NULL, "val2", "%t", "%t", "%n", NULL},
 	5,
       },
     },
@@ -1342,13 +1342,13 @@ genders_database_data_t genders_database_data_subst_escape_char =
     11,
   };
 
-genders_database_t genders_database_subst_escape_char = 
+genders_database_t genders_database_subst_escape_char =
   {
     "testdatabases/genders.subst_escape_char",
     &genders_database_data_subst_escape_char,
   };
 
-genders_database_data_t genders_database_data_subst_nodename = 
+genders_database_data_t genders_database_data_subst_nodename =
   {
     "node1",
     "attr1",
@@ -1361,23 +1361,23 @@ genders_database_data_t genders_database_data_subst_nodename =
     5,
     5,
     {"node1", "node2", NULL},
-    2,				
+    2,
     {"attr1", "attr2", "attr3", NULL},
     3,
     /* Can't test "%n", so make NULL so test is not run */
-    {NULL,    "val2",  NULL,    NULL}, 
+    {NULL,    "val2",  NULL,    NULL},
     3,
     {
       {
 	{"attr1", "attr2", "attr3", NULL},
-	{"", "val2", "node1", NULL}, 
-	{NULL, "val2", "node1", NULL}, 
+	{"", "val2", "node1", NULL},
+	{NULL, "val2", "node1", NULL},
 	3,
       },
       {
 	{"attr1", "attr2", "attr3", NULL},
-	{"", "val2", "node2", NULL}, 
-	{NULL, "val2", "node2", NULL}, 
+	{"", "val2", "node2", NULL},
+	{NULL, "val2", "node2", NULL},
 	3,
       },
     },
@@ -1435,25 +1435,25 @@ genders_database_data_t genders_database_data_subst_nodename =
     8,
   };
 
-genders_database_t genders_database_subst_nodename = 
+genders_database_t genders_database_subst_nodename =
   {
     "testdatabases/genders.subst_nodename",
     &genders_database_data_subst_nodename,
   };
 
-genders_database_t genders_database_subst_nodename_comma = 
+genders_database_t genders_database_subst_nodename_comma =
   {
     "testdatabases/genders.subst_nodename_comma",
     &genders_database_data_subst_nodename,
   };
 
-genders_database_t genders_database_subst_nodename_hostrange = 
+genders_database_t genders_database_subst_nodename_hostrange =
   {
     "testdatabases/genders.subst_nodename_hostrange",
     &genders_database_data_subst_nodename,
   };
 
-genders_database_data_t genders_database_data_large_attr = 
+genders_database_data_t genders_database_data_large_attr =
   {
     "node1",
     "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
@@ -1466,7 +1466,7 @@ genders_database_data_t genders_database_data_large_attr =
     78,
     0,
     {"node1", NULL},
-    1,				
+    1,
     {"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", NULL},
     1,
     {NULL, NULL},
@@ -1474,8 +1474,8 @@ genders_database_data_t genders_database_data_large_attr =
     {
       {
 	{"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", NULL},
-	{"", NULL}, 
-	{NULL, NULL}, 
+	{"", NULL},
+	{NULL, NULL},
 	1,
       },
     },
@@ -1503,13 +1503,13 @@ genders_database_data_t genders_database_data_large_attr =
     3,
   };
 
-genders_database_t genders_database_large_attr = 
+genders_database_t genders_database_large_attr =
   {
     "testdatabases/genders.large_attr",
     &genders_database_data_large_attr,
   };
 
-genders_database_data_t genders_database_data_large_val = 
+genders_database_data_t genders_database_data_large_val =
   {
     "node1",
     NULL,
@@ -1522,14 +1522,14 @@ genders_database_data_t genders_database_data_large_val =
     5,
     78,
     {"node1", NULL},
-    1,				
+    1,
     {"attr1", NULL},
     1,
     {"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", NULL},
     1,
     {
       {
-	{"attr1", NULL}, 
+	{"attr1", NULL},
 	{"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", NULL},
 	{"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", NULL},
 	1,
@@ -1565,13 +1565,13 @@ genders_database_data_t genders_database_data_large_val =
     4,
   };
 
-genders_database_t genders_database_large_val = 
+genders_database_t genders_database_large_val =
   {
     "testdatabases/genders.large_val",
     &genders_database_data_large_val,
   };
 
-genders_database_t *genders_functionality_databases[] = 
+genders_database_t *genders_functionality_databases[] =
   {
     &genders_database_base,
     &genders_database_base_comma,
@@ -1626,12 +1626,12 @@ genders_database_t *genders_functionality_databases[] =
     NULL,
   };
 
-genders_database_data_t genders_database_data_flag_test_raw_values = 
+genders_database_data_t genders_database_data_flag_test_raw_values =
   {
     "node1",
-    NULL,			
-    "escape1",			
-    "%t",			
+    NULL,
+    "escape1",
+    "%t",
     1,
     4,
     4,
@@ -1639,7 +1639,7 @@ genders_database_data_t genders_database_data_flag_test_raw_values =
     7,
     5,
     {"node1", NULL},
-    1,				
+    1,
     {"escape1", "escape2", "escape3", "escape4", NULL},
     4,
     {"%t", "%t", "%n", "node1", NULL},
@@ -1718,7 +1718,7 @@ genders_database_data_t genders_database_data_flag_test_raw_values =
     10,
   };
 
-genders_database_t genders_database_flag_test_raw_values = 
+genders_database_t genders_database_flag_test_raw_values =
   {
     "testdatabases/genders.flag_test_raw_values",
     &genders_database_data_flag_test_raw_values,

--- a/src/testsuite/libgenders/genders_test_database.h
+++ b/src/testsuite/libgenders/genders_test_database.h
@@ -88,7 +88,7 @@ typedef struct {
   } node_attrvals[GENDERS_DATABASE_MAXNODES];
   int node_attrvals_len;
   /* attrval_nodes
-   * - Lists nodes based on attr or attr=val combinations. 
+   * - Lists nodes based on attr or attr=val combinations.
    * - For use with genders_getnodes, genders_query, and genders_testquery
    */
   struct {

--- a/src/testsuite/libgenders/genders_test_functionality.c
+++ b/src/testsuite/libgenders/genders_test_functionality.c
@@ -97,7 +97,7 @@ genders_handle_destroy_functionality(int verbose)
 
   return_value = genders_handle_destroy(handle);
   errnum = genders_errnum(handle);
-  
+
   err = genders_return_value_errnum_check("genders_handle_destroy",
 					  num,
 					  0,
@@ -123,7 +123,7 @@ genders_handle_destroy_functionality(int verbose)
 
   return_value = genders_handle_destroy(handle);
   errnum = genders_errnum(handle);
-  
+
   err = genders_return_value_errnum_check("genders_handle_destroy",
 					  num,
 					  0,
@@ -181,7 +181,7 @@ genders_load_data_functionality(int verbose)
 	i++;
       }
   }
-  
+
   /* Part B: Load functionality test databases without errors */
   {
     int i = 0;
@@ -206,7 +206,7 @@ genders_load_data_functionality(int verbose)
 						errnum,
 						databases[i]->filename,
 						verbose);
-	
+
 	if (genders_handle_destroy(handle) < 0)
 	  genders_err_exit("genders_handle_destroy");
 
@@ -229,17 +229,17 @@ genders_errnum_functionality(int verbose)
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   if (genders_load_data(handle, genders_database_base.filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
   for (i = GENDERS_ERR_SUCCESS; i <= GENDERS_ERR_ERRNUMRANGE; i++)
     {
       int errnum, err;
 
       genders_set_errnum(handle, i);
       errnum = genders_errnum(handle);
-	
+
       err = genders_errnum_check("genders_errnum",
 				 num,
 				 i,
@@ -266,10 +266,10 @@ genders_strerror_functionality(int verbose)
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   if (genders_load_data(handle, genders_database_base.filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
   for (i = GENDERS_ERR_SUCCESS; i <= GENDERS_ERR_ERRNUMRANGE; i++)
     {
       char *expected_string, *string;
@@ -278,7 +278,7 @@ genders_strerror_functionality(int verbose)
       genders_set_errnum(handle, i);
       expected_string = genders_errormsg(handle);
       string = genders_strerror(i);
-	
+
       err = genders_string_check("genders_strerror",
 				 num,
 				 expected_string,
@@ -308,10 +308,10 @@ genders_errormsg_functionality(int verbose)
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   if (genders_load_data(handle, genders_database_base.filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
   for (i = GENDERS_ERR_SUCCESS; i <= GENDERS_ERR_ERRNUMRANGE; i++)
     {
       char *expected_string, *string;
@@ -320,7 +320,7 @@ genders_errormsg_functionality(int verbose)
       expected_string = genders_strerror(i);
       genders_set_errnum(handle, i);
       string = genders_errormsg(handle);
-	
+
       err = genders_string_check("genders_errormsg",
 				 num,
 				 expected_string,
@@ -354,10 +354,10 @@ genders_perror_functionality(int verbose)
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   if (genders_load_data(handle, genders_database_base.filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
   for (i = GENDERS_ERR_SUCCESS; i <= GENDERS_ERR_ERRNUMRANGE; i++)
     {
       char *expected_string;
@@ -368,7 +368,7 @@ genders_perror_functionality(int verbose)
 
       if (pipe(fds) < 0)
 	genders_err_exit("pipe: %s", strerror(errno));
-      
+
       genders_set_errnum(handle, i);
       expected_string = genders_strerror(i);
 
@@ -409,7 +409,7 @@ genders_perror_functionality(int verbose)
 
       if (pipe(fds) < 0)
 	genders_err_exit("pipe: %s", strerror(errno));
-      
+
       genders_set_errnum(handle, i);
       expected_string = genders_strerror(i);
 
@@ -462,7 +462,7 @@ _genders_get_flags_functionality_common(genders_t handle,
 
   if (genders_set_flags(handle, flag) < 0)
     genders_err_exit("genders_set_flags: %s", genders_errormsg(handle));
-	
+
   return_value = genders_get_flags(handle, &tmpflags);
   errnum = genders_errnum(handle);
 
@@ -474,7 +474,7 @@ _genders_get_flags_functionality_common(genders_t handle,
 					  errnum,
 					  flag_str,
 					  verbose);
-  
+
   errcount += err;
   (*num)++;
 
@@ -500,14 +500,14 @@ genders_get_flags_functionality(int verbose)
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   err = _genders_get_flags_functionality_common(handle,
 						&num,
 						GENDERS_FLAG_DEFAULT,
 						"GENDERS_FLAG_DEFAULT",
 						verbose);
   errcount += err;
-  
+
   err = _genders_get_flags_functionality_common(handle,
 						&num,
 						GENDERS_FLAG_RAW_VALUES,
@@ -536,7 +536,7 @@ _genders_set_flags_functionality_common(genders_t handle,
 
   return_value = genders_set_flags(handle, flag);
   errnum = genders_errnum(handle);
-  
+
   err = genders_return_value_errnum_check("genders_set_flags",
 					  (*num),
 					  0,
@@ -545,13 +545,13 @@ _genders_set_flags_functionality_common(genders_t handle,
 					  errnum,
 					  flag_str,
 					  verbose);
-  
+
   errcount += err;
   (*num)++;
-  
+
   if (genders_get_flags(handle, &tmpflags) < 0)
     genders_err_exit("genders_get_flags: %s", genders_errormsg(handle));
-  
+
   err = genders_flag_check("genders_set_flags",
 			   (*num),
 			   flag,
@@ -584,15 +584,15 @@ _genders_set_flags_raw_values(int *num,
   if (genders_load_data(handle, database->filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
 
-  if ((attrlist_len = genders_attrlist_create(handle, &attrlist)) < 0) 
+  if ((attrlist_len = genders_attrlist_create(handle, &attrlist)) < 0)
     genders_err_exit("genders_attrlist_create: %s", genders_errormsg(handle));
-      
-  if ((vallist_len = genders_vallist_create(handle, &vallist)) < 0) 
+
+  if ((vallist_len = genders_vallist_create(handle, &vallist)) < 0)
     genders_err_exit("genders_vallist_create: %s", genders_errormsg(handle));
 
   if (genders_set_flags(handle, GENDERS_FLAG_RAW_VALUES) < 0)
     genders_err_exit("genders_set_flags: %s", genders_errormsg(handle));
- 
+
   /* Note: we're cheating, vals_string represents the substituted
    * values, vals_input represents the raw values.  This is not what
    * is typically done.
@@ -603,7 +603,7 @@ _genders_set_flags_raw_values(int *num,
 				 vallist,
 				 attrlist_len,
 				 database->data->node);
-  
+
   errnum = genders_errnum(handle);
 
   err = genders_return_value_errnum_attrval_list_check("genders_set_flags",
@@ -637,9 +637,9 @@ _genders_set_flags_raw_values(int *num,
 				 vallist,
 				 attrlist_len,
 				 database->data->node);
-  
+
   errnum = genders_errnum(handle);
-  
+
   err = genders_return_value_errnum_attrval_list_check("genders_set_flags",
 						       (*num),
 						       database->data->node_attrvals[0].attrslen,
@@ -678,7 +678,7 @@ genders_set_flags_functionality(int verbose)
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-   
+
   /* Part 1: Test Basics */
 
   err = _genders_set_flags_functionality_common(handle,
@@ -687,7 +687,7 @@ genders_set_flags_functionality(int verbose)
 						"GENDERS_FLAG_DEFAULT",
 						verbose);
   errcount += err;
-  
+
   err = _genders_set_flags_functionality_common(handle,
 						&num,
 						GENDERS_FLAG_RAW_VALUES,
@@ -709,7 +709,7 @@ genders_set_flags_functionality(int verbose)
 }
 
 static int
-_genders_getfunc_functionality(GendersGetFunc func, 
+_genders_getfunc_functionality(GendersGetFunc func,
 			       char *funcname,
 			       char *filename,
 			       int num,
@@ -720,7 +720,7 @@ _genders_getfunc_functionality(GendersGetFunc func,
 {
   genders_t handle;
   int return_value, errnum, err;
-	
+
   assert(func && funcname && filename);
 
   if (!(handle = genders_handle_create()))
@@ -731,7 +731,7 @@ _genders_getfunc_functionality(GendersGetFunc func,
 
   return_value = func(handle);
   errnum = genders_errnum(handle);
-		 
+
   err = genders_return_value_errnum_check(funcname,
 					  num,
 					  expected_return_value,
@@ -758,16 +758,16 @@ genders_getnumnodes_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_getfunc_functionality(genders_getnumnodes,
 					   "genders_getnumnodes",
 					   databases[i]->filename,
-					   num, 
+					   num,
 					   databases[i]->data->numnodes,
 					   GENDERS_ERR_SUCCESS,
 					   databases[i]->filename,
 					   verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -787,16 +787,16 @@ genders_getnumattrs_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_getfunc_functionality(genders_getnumattrs,
 					   "genders_getnumattrs",
 					   databases[i]->filename,
-					   num, 
+					   num,
 					   databases[i]->data->numattrs,
 					   GENDERS_ERR_SUCCESS,
 					   databases[i]->filename,
 					   verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -816,16 +816,16 @@ genders_getmaxattrs_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_getfunc_functionality(genders_getmaxattrs,
 					   "genders_getmaxattrs",
 					   databases[i]->filename,
-					   num, 
+					   num,
 					   databases[i]->data->maxattrs,
 					   GENDERS_ERR_SUCCESS,
 					   databases[i]->filename,
 					   verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -866,7 +866,7 @@ genders_getmaxnodelen_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err, maxnodelen;
-      
+
       if (hostnamelen > databases[i]->data->maxnodelen)
 	maxnodelen = hostnamelen;
       else
@@ -874,12 +874,12 @@ genders_getmaxnodelen_functionality(int verbose)
       err = _genders_getfunc_functionality(genders_getmaxnodelen,
 					   "genders_getmaxnodelen",
 					   databases[i]->filename,
-					   num, 
+					   num,
 					   maxnodelen,
 					   GENDERS_ERR_SUCCESS,
 					   databases[i]->filename,
 					   verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -899,16 +899,16 @@ genders_getmaxattrlen_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_getfunc_functionality(genders_getmaxattrlen,
 					   "genders_getmaxattrlen",
 					   databases[i]->filename,
-					   num, 
+					   num,
 					   databases[i]->data->maxattrlen,
 					   GENDERS_ERR_SUCCESS,
 					   databases[i]->filename,
 					   verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -928,16 +928,16 @@ genders_getmaxvallen_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_getfunc_functionality(genders_getmaxvallen,
 					   "genders_getmaxvallen",
 					   databases[i]->filename,
-					   num, 
+					   num,
 					   databases[i]->data->maxvallen,
 					   GENDERS_ERR_SUCCESS,
 					   databases[i]->filename,
 					   verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -960,18 +960,18 @@ _genders_list_create_functionality(GendersListCreateFunc funccreate,
   genders_t handle;
   char **list;
   int return_value, errnum, retval = 0;
-  
+
   assert(funccreate && funcdestroy && funcname);
-  
+
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   if (genders_load_data(handle, filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-  
+
   return_value = funccreate(handle, &list);
   errnum = genders_errnum(handle);
-  
+
   retval = genders_return_value_errnum_check(funcname,
 					     num,
 					     expected_return_value,
@@ -980,7 +980,7 @@ _genders_list_create_functionality(GendersListCreateFunc funccreate,
 					     errnum,
 					     msg,
 					     verbose);
-  
+
   if (expected_return_value >= 0
       && expected_return_value == retval
       && errnum == GENDERS_ERR_SUCCESS)
@@ -988,10 +988,10 @@ _genders_list_create_functionality(GendersListCreateFunc funccreate,
       if (funcdestroy(handle, list) < 0)
 	genders_err_exit("funcdestroy: %s", genders_errormsg(handle));
     }
-  
+
   if (genders_handle_destroy(handle) < 0)
     genders_err_exit("genders_handle_destroy");
-  
+
   return retval;
 }
 
@@ -1015,7 +1015,7 @@ _genders_list_clear_functionality(GendersListCreateFunc funccreate,
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   if (genders_load_data(handle, filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
 
@@ -1024,12 +1024,12 @@ _genders_list_clear_functionality(GendersListCreateFunc funccreate,
 
   return_value = funcclear(handle, list);
   errnum = genders_errnum(handle);
-  
+
   err = genders_return_value_errnum_list_check(funcname,
 					       num,
 					       0,
 					       GENDERS_ERR_SUCCESS,
-					       NULL, 
+					       NULL,
 					       0,
 					       return_value,
 					       errnum,
@@ -1043,7 +1043,7 @@ _genders_list_clear_functionality(GendersListCreateFunc funccreate,
     genders_err_exit("funcdestroy: %s", genders_errormsg(handle));
   if (genders_handle_destroy(handle) < 0)
     genders_err_exit("genders_handle_destroy: %s", genders_errormsg(handle));
-  
+
   return retval;
 }
 
@@ -1066,7 +1066,7 @@ _genders_list_destroy_functionality(GendersListCreateFunc funccreate,
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   if (genders_load_data(handle, filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
 
@@ -1075,7 +1075,7 @@ _genders_list_destroy_functionality(GendersListCreateFunc funccreate,
 
   return_value = funcdestroy(handle, list);
   errnum = genders_errnum(handle);
-      
+
   retval = genders_return_value_errnum_check(funcname,
 					     num,
 					     expected_return_value,
@@ -1103,17 +1103,17 @@ genders_nodelist_create_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_create_functionality(genders_nodelist_create,
 					       genders_nodelist_destroy,
 					       "genders_nodelist_create",
 					       databases[i]->filename,
-					       num, 
+					       num,
 					       databases[i]->data->numnodes,
 					       GENDERS_ERR_SUCCESS,
 					       databases[i]->filename,
 					       verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1133,18 +1133,18 @@ genders_nodelist_clear_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_clear_functionality(genders_nodelist_create,
 					      genders_nodelist_clear,
 					      genders_nodelist_destroy,
 					      "genders_nodelist_clear",
 					      databases[i]->filename,
-					      num, 
+					      num,
 					      0,
 					      GENDERS_ERR_SUCCESS,
 					      databases[i]->filename,
 					      verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1164,17 +1164,17 @@ genders_nodelist_destroy_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_destroy_functionality(genders_nodelist_create,
 						genders_nodelist_destroy,
 						"genders_nodelist_destroy",
 						databases[i]->filename,
-						num, 
+						num,
 						0,
 						GENDERS_ERR_SUCCESS,
 						databases[i]->filename,
 						verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1194,17 +1194,17 @@ genders_attrlist_create_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_create_functionality(genders_attrlist_create,
 					       genders_attrlist_destroy,
 					       "genders_attrlist_create",
 					       databases[i]->filename,
-					       num, 
+					       num,
 					       databases[i]->data->numattrs,
 					       GENDERS_ERR_SUCCESS,
 					       databases[i]->filename,
 					       verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1224,18 +1224,18 @@ genders_attrlist_clear_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_clear_functionality(genders_nodelist_create,
 					      genders_nodelist_clear,
 					      genders_nodelist_destroy,
 					      "genders_nodelist_clear",
 					      databases[i]->filename,
-					      num, 
+					      num,
 					      0,
 					      GENDERS_ERR_SUCCESS,
 					      databases[i]->filename,
 					      verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1255,17 +1255,17 @@ genders_attrlist_destroy_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_destroy_functionality(genders_attrlist_create,
 						genders_attrlist_destroy,
 						"genders_attrlist_destroy",
 						databases[i]->filename,
-						num, 
+						num,
 						0,
 						GENDERS_ERR_SUCCESS,
 						databases[i]->filename,
 						verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1285,17 +1285,17 @@ genders_vallist_create_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_create_functionality(genders_vallist_create,
 					       genders_vallist_destroy,
 					       "genders_vallist_create",
 					       databases[i]->filename,
-					       num, 
+					       num,
 					       databases[i]->data->numattrs,
 					       GENDERS_ERR_SUCCESS,
 					       databases[i]->filename,
 					       verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1315,18 +1315,18 @@ genders_vallist_clear_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_clear_functionality(genders_vallist_create,
 					      genders_vallist_clear,
 					      genders_vallist_destroy,
 					      "genders_vallist_clear",
 					      databases[i]->filename,
-					      num, 
+					      num,
 					      0,
 					      GENDERS_ERR_SUCCESS,
 					      databases[i]->filename,
 					      verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1346,17 +1346,17 @@ genders_vallist_destroy_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int err;
-      
+
       err = _genders_list_destroy_functionality(genders_vallist_create,
 						genders_vallist_destroy,
 						"genders_vallist_destroy",
 						databases[i]->filename,
-						num, 
+						num,
 						0,
 						GENDERS_ERR_SUCCESS,
 						databases[i]->filename,
 						verbose);
-      
+
       errcount += err;
       num++;
       i++;
@@ -1388,18 +1388,18 @@ genders_getnodename_functionality(int verbose)
     {
       char testbuf[MAXHOSTNAMELEN+1];
       int return_value, errnum, err;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-      
+
       return_value = genders_getnodename(handle, testbuf, MAXHOSTNAMELEN);
       errnum = genders_errnum(handle);
-      
+
       err = genders_return_value_errnum_string_check("genders_getnodename",
-						     num, 
+						     num,
 						     0,
 						     GENDERS_ERR_SUCCESS,
 						     nodenamebuf,
@@ -1408,10 +1408,10 @@ genders_getnodename_functionality(int verbose)
 						     testbuf,
 						     databases[i]->filename,
 						     verbose);
-      
+
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-      
+
       errcount += err;
       num++;
       i++;
@@ -1433,25 +1433,25 @@ genders_getnodes_functionality(int verbose)
     {
       int j, nodelist_len, return_value, errnum, err;
       char **nodelist;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-      
-      if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0) 
+
+      if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0)
 	genders_err_exit("genders_nodelist_create: %s", genders_errormsg(handle));
-	  
+
       for (j = 0; j < databases[i]->data->attrval_nodes_len; j++)
 	{
-	  return_value = genders_getnodes(handle, 
+	  return_value = genders_getnodes(handle,
 					  nodelist,
 					  nodelist_len,
 					  databases[i]->data->attrval_nodes[j].attr,
 					  databases[i]->data->attrval_nodes[j].val);
 	  errnum = genders_errnum(handle);
-	    
+
 	  err = genders_return_value_errnum_list_check("genders_getnodes",
 						       num,
 						       databases[i]->data->attrval_nodes[j].nodeslen,
@@ -1465,7 +1465,7 @@ genders_getnodes_functionality(int verbose)
 						       GENDERS_COMPARISON_MATCH,
 						       databases[i]->filename,
 						       verbose);
-	  
+
 	  errcount += err;
 	}
 
@@ -1476,7 +1476,7 @@ genders_getnodes_functionality(int verbose)
 				      GENDERS_DATABASE_INVALID_ATTR,
 				      NULL);
       errnum = genders_errnum(handle);
-      
+
       err = genders_return_value_errnum_check("genders_getnodes",
 					      num,
 					      0,
@@ -1496,7 +1496,7 @@ genders_getnodes_functionality(int verbose)
 					  databases[i]->data->attr_with_val,
 					  GENDERS_DATABASE_INVALID_VAL);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_getnodes",
 						  num,
 						  0,
@@ -1512,7 +1512,7 @@ genders_getnodes_functionality(int verbose)
 	genders_err_exit("genders_nodelist_destroy: %s", genders_errormsg(handle));
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-      
+
       num++;
       i++;
     }
@@ -1533,26 +1533,26 @@ genders_getattr_functionality(int verbose)
     {
       int j, attrlist_len, vallist_len, return_value, errnum, err;
       char **attrlist, **vallist;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-      
-      if ((attrlist_len = genders_attrlist_create(handle, &attrlist)) < 0) 
+
+      if ((attrlist_len = genders_attrlist_create(handle, &attrlist)) < 0)
 	genders_err_exit("genders_attrlist_create: %s", genders_errormsg(handle));
-      
-      if ((vallist_len = genders_vallist_create(handle, &vallist)) < 0) 
+
+      if ((vallist_len = genders_vallist_create(handle, &vallist)) < 0)
 	genders_err_exit("genders_vallist_create: %s", genders_errormsg(handle));
-      
+
       for (j = 0; j < databases[i]->data->nodeslen; j++)
 	{
 	  err = 0;
-	  return_value = genders_getattr(handle, 
-					 attrlist, 
-					 vallist, 
-					 attrlist_len, 
+	  return_value = genders_getattr(handle,
+					 attrlist,
+					 vallist,
+					 attrlist_len,
 					 databases[i]->data->nodes[j]);
 	  errnum = genders_errnum(handle);
 
@@ -1582,7 +1582,7 @@ genders_getattr_functionality(int verbose)
 					 attrlist_len,
 					 GENDERS_DATABASE_INVALID_NODE);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_getattr",
 						  num,
 						  -1,
@@ -1600,7 +1600,7 @@ genders_getattr_functionality(int verbose)
 	genders_err_exit("genders_vallist_destroy: %s", genders_errormsg(handle));
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-	
+
       num++;
       i++;
     }
@@ -1621,19 +1621,19 @@ genders_getattr_all_functionality(int verbose)
     {
       int attrlist_len, return_value, errnum, err;
       char **attrlist;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-      
-      if ((attrlist_len = genders_attrlist_create(handle, &attrlist)) < 0) 
+
+      if ((attrlist_len = genders_attrlist_create(handle, &attrlist)) < 0)
 	genders_err_exit("genders_attrlist_create: %s", genders_errormsg(handle));
-      
+
       return_value = genders_getattr_all(handle, attrlist, attrlist_len);
       errnum = genders_errnum(handle);
-      
+
       err = genders_return_value_errnum_list_check("genders_getattr_all",
 						   num,
 						   databases[i]->data->numattrs,
@@ -1652,7 +1652,7 @@ genders_getattr_all_functionality(int verbose)
 	genders_err_exit("genders_attrlist_destroy: %s", genders_errormsg(handle));
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-      
+
       errcount += err;
       num++;
       i++;
@@ -1669,37 +1669,37 @@ genders_testattr_functionality(int verbose)
   int num = 0;
   int i = 0;
   genders_database_t **databases = &genders_functionality_databases[0];
-  
+
   while (databases[i] != NULL)
     {
       int j, maxvallen, return_value, errnum, err;
       char *valbuf;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
       if ((maxvallen = genders_getmaxvallen(handle)) < 0)
 	genders_err_exit("genders_getmaxvallen: %s", genders_errormsg(handle));
       if (!(valbuf = (char *)malloc(maxvallen + 1)))
 	genders_err_exit("malloc: %s", strerror(errno));
-      
+
       for (j = 0; j < databases[i]->data->nodeslen; j++)
 	{
 	  int k;
 	  for (k = 0; k < databases[i]->data->node_attrvals[j].attrslen; k++)
 	    {
-	      return_value = genders_testattr(handle, 
+	      return_value = genders_testattr(handle,
 					      databases[i]->data->nodes[j],
 					      databases[i]->data->node_attrvals[j].attrs[k],
 					      valbuf,
 					      maxvallen + 1);
 	      errnum = genders_errnum(handle);
-	      
+
 	      err = genders_return_value_errnum_string_check("genders_testattr",
-							     num, 
+							     num,
 							     1,
 							     GENDERS_ERR_SUCCESS,
 							     databases[i]->data->node_attrvals[j].vals_string[k],
@@ -1708,11 +1708,11 @@ genders_testattr_functionality(int verbose)
 							     valbuf,
 							     databases[i]->filename,
 							     verbose);
-		
+
 	      errcount += err;
 	    }
 	}
-      
+
       /* Test invalid node */
       if (databases[i]->data->node && databases[i]->data->attr_with_val)
 	{
@@ -1722,7 +1722,7 @@ genders_testattr_functionality(int verbose)
 					  valbuf,
 					  maxvallen + 1);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_testattr",
 						  num,
 						  -1,
@@ -1735,13 +1735,13 @@ genders_testattr_functionality(int verbose)
 	}
 
       /* Test invalidate attribute */
-      return_value = genders_testattr(handle, 
+      return_value = genders_testattr(handle,
 				      databases[i]->data->node,
 				      GENDERS_DATABASE_INVALID_ATTR,
 				      valbuf,
 				      maxvallen + 1);
       errnum = genders_errnum(handle);
-      
+
       err = genders_return_value_errnum_check("genders_testattr",
 					      num,
                                               (databases[i]->data->node) ? 0 : -1,
@@ -1755,7 +1755,7 @@ genders_testattr_functionality(int verbose)
       free(valbuf);
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-      
+
       num++;
       i++;
     }
@@ -1775,24 +1775,24 @@ genders_testattrval_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int j, return_value, errnum, err;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-      
+
       for (j = 0; j < databases[i]->data->nodeslen; j++)
 	{
 	  int k;
 	  for (k = 0; k < databases[i]->data->node_attrvals[j].attrslen; k++)
 	    {
-	      return_value = genders_testattrval(handle, 
+	      return_value = genders_testattrval(handle,
 						 databases[i]->data->nodes[j],
 						 databases[i]->data->node_attrvals[j].attrs[k],
 						 databases[i]->data->node_attrvals[j].vals_input[k]);
 	      errnum = genders_errnum(handle);
-	      
+
 	      err = genders_return_value_errnum_check("genders_testattrval",
 						      num,
 						      1,
@@ -1804,7 +1804,7 @@ genders_testattrval_functionality(int verbose)
 	      errcount += err;
 	    }
 	}
-      
+
       /* Test invalid node */
       if (databases[i]->data->node && databases[i]->data->attr_with_val && databases[i]->data->val)
 	{
@@ -1813,7 +1813,7 @@ genders_testattrval_functionality(int verbose)
 					     databases[i]->data->attr_with_val,
 					     databases[i]->data->val);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_testattrval",
 						  num,
 						  -1,
@@ -1828,12 +1828,12 @@ genders_testattrval_functionality(int verbose)
       /* Test attr without val */
       if (databases[i]->data->attr_without_val && databases[i]->data->val)
 	{
-	  return_value = genders_testattrval(handle, 
+	  return_value = genders_testattrval(handle,
 					     databases[i]->data->node,
 					     databases[i]->data->attr_without_val,
 					     databases[i]->data->val);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_testattrval",
 						  num,
 						  0,
@@ -1844,16 +1844,16 @@ genders_testattrval_functionality(int verbose)
 						  verbose);
 	  errcount += err;
 	}
-      
+
       /* Test attr with val, but invalid val */
       if (databases[i]->data->attr_with_val)
 	{
-	  return_value = genders_testattrval(handle, 
+	  return_value = genders_testattrval(handle,
 					     databases[i]->data->node,
 					     databases[i]->data->attr_with_val,
 					     GENDERS_DATABASE_INVALID_VAL);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_testattrval",
 						  num,
 						  0,
@@ -1862,7 +1862,7 @@ genders_testattrval_functionality(int verbose)
 						  errnum,
 						  databases[i]->filename,
 						  verbose);
-	  
+
 	  errcount += err;
 	}
 
@@ -1888,18 +1888,18 @@ genders_isnode_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int j, return_value, errnum, err;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-      
+
       for (j = 0; j < databases[i]->data->nodeslen; j++)
 	{
 	  return_value = genders_isnode(handle, databases[i]->data->nodes[j]);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_isnode",
 						  num,
 						  1,
@@ -1910,11 +1910,11 @@ genders_isnode_functionality(int verbose)
 						  verbose);
 	  errcount += err;
 	}
-      
+
       /* Test invalid node */
       return_value = genders_isnode(handle, GENDERS_DATABASE_INVALID_NODE);
       errnum = genders_errnum(handle);
-      
+
       err = genders_return_value_errnum_check("genders_isnode",
 					      num,
 					      0,
@@ -1927,7 +1927,7 @@ genders_isnode_functionality(int verbose)
 
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-      
+
       num++;
       i++;
     }
@@ -1947,18 +1947,18 @@ genders_isattr_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int j, return_value, errnum, err;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-	
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-      
+
       for (j = 0; j < databases[i]->data->attrslen; j++)
 	{
 	  return_value = genders_isattr(handle, databases[i]->data->attrs[j]);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_isattr",
 						  num,
 						  1,
@@ -1969,11 +1969,11 @@ genders_isattr_functionality(int verbose)
 						  verbose);
 	  errcount += err;
 	}
-      
+
       /* Test invalid attr */
       return_value = genders_isattr(handle, GENDERS_DATABASE_INVALID_ATTR);
       errnum = genders_errnum(handle);
-      
+
       err = genders_return_value_errnum_check("genders_isattr",
 					      num,
 					      0,
@@ -1983,10 +1983,10 @@ genders_isattr_functionality(int verbose)
 					      databases[i]->filename,
 					      verbose);
       errcount += err;
-      
+
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-      
+
       num++;
       i++;
     }
@@ -2006,23 +2006,23 @@ genders_isattrval_functionality(int verbose)
   while (databases[i] != NULL)
     {
       int j, return_value, errnum, err;
-      
+
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
       for (j = 0; j < databases[i]->data->attrslen; j++)
 	{
 	  if (!databases[i]->data->vals[j])
 	    continue;
 
-	  return_value = genders_isattrval(handle, 
+	  return_value = genders_isattrval(handle,
 					   databases[i]->data->attrs[j],
 					   databases[i]->data->vals[j]);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_isattrval",
 						  num,
 						  1,
@@ -2033,15 +2033,15 @@ genders_isattrval_functionality(int verbose)
 						  verbose);
 	  errcount += err;
 	}
-      
+
       /* Test attr without val */
       if (databases[i]->data->attr_without_val && databases[i]->data->val)
 	{
-	  return_value = genders_isattrval(handle, 
+	  return_value = genders_isattrval(handle,
 					   databases[i]->data->attr_without_val,
 					   databases[i]->data->val);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_isattrval",
 						  num,
 						  0,
@@ -2052,15 +2052,15 @@ genders_isattrval_functionality(int verbose)
 						  verbose);
 	  errcount += err;
 	}
-      
+
       /* Test attr with val, but invalid val */
       if (databases[i]->data->attr_with_val)
 	{
-	  return_value = genders_isattrval(handle, 
+	  return_value = genders_isattrval(handle,
 					   databases[i]->data->attr_with_val,
 					   GENDERS_DATABASE_INVALID_VAL);
 	  errnum = genders_errnum(handle);
-	  
+
 	  err = genders_return_value_errnum_check("genders_isattrval",
 						  num,
 						  0,
@@ -2071,10 +2071,10 @@ genders_isattrval_functionality(int verbose)
 						  verbose);
 	  errcount += err;
 	}
-	  
+
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-	  
+
       num++;
       i++;
     }
@@ -2103,18 +2103,18 @@ genders_index_attrvals_functionality(int verbose)
 
       if (!(handle = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handle, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-      
+
       for (j = 0; j < databases[i]->data->attrslen; j++)
 	{
 	  err = 0;
 	  return_value = genders_index_attrvals(handle, databases[i]->data->attrs[j]);
 	  errnum = genders_errnum(handle);
-      
+
 	  err += genders_return_value_errnum_check("genders_index_attrvals",
-						   num, 
+						   num,
 						   0,
 						   GENDERS_ERR_SUCCESS,
 						   return_value,
@@ -2129,18 +2129,18 @@ genders_index_attrvals_functionality(int verbose)
 	      char **nodelist;
 	      int nodelist_len;
 
-	      if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0) 
+	      if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0)
 		genders_err_exit("genders_nodelist_create: %s", genders_errormsg(handle));
-	  
+
 	      for (k = 0; k < databases[i]->data->attrval_nodes_len; k++)
 		{
-		  return_value = genders_getnodes(handle, 
+		  return_value = genders_getnodes(handle,
 						  nodelist,
 						  nodelist_len,
 						  databases[i]->data->attrval_nodes[k].attr,
 						  databases[i]->data->attrval_nodes[k].val);
 		  errnum = genders_errnum(handle);
-		  
+
 		  err += genders_return_value_errnum_list_check("genders_index_attrvals:genders_getnodes",
 								num,
 								databases[i]->data->attrval_nodes[k].nodeslen,
@@ -2163,7 +2163,7 @@ genders_index_attrvals_functionality(int verbose)
 					      GENDERS_DATABASE_INVALID_ATTR,
 					      NULL);
 	      errnum = genders_errnum(handle);
-	      
+
 	      err += genders_return_value_errnum_check("genders_index_attrvals:genders_getnodes",
 						       num,
 						       0,
@@ -2182,7 +2182,7 @@ genders_index_attrvals_functionality(int verbose)
 						  databases[i]->data->attr_with_val,
 						  GENDERS_DATABASE_INVALID_VAL);
 		  errnum = genders_errnum(handle);
-		  
+
 		  err += genders_return_value_errnum_check("genders_index_attrvals:genders_getnodes",
 							   num,
 							   0,
@@ -2205,12 +2205,12 @@ genders_index_attrvals_functionality(int verbose)
 		{
 		  if (!databases[i]->data->vals[k])
 		    continue;
-		  
-		  return_value = genders_isattrval(handle, 
+
+		  return_value = genders_isattrval(handle,
 						   databases[i]->data->attrs[k],
 						   databases[i]->data->vals[k]);
 		  errnum = genders_errnum(handle);
-		  
+
 		  err += genders_return_value_errnum_check("genders_index_attrvals:genders_isattrval",
 							   num,
 							   1,
@@ -2220,15 +2220,15 @@ genders_index_attrvals_functionality(int verbose)
 							   databases[i]->filename,
 							   verbose);
 		}
-	      
+
 	      /* Test attr without val */
 	      if (databases[i]->data->attr_without_val && databases[i]->data->val)
 		{
-		  return_value = genders_isattrval(handle, 
+		  return_value = genders_isattrval(handle,
 						   databases[i]->data->attr_without_val,
 						   databases[i]->data->val);
 		  errnum = genders_errnum(handle);
-		  
+
 		  err += genders_return_value_errnum_check("genders_index_attrvals:genders_isattrval",
 							   num,
 							   0,
@@ -2238,15 +2238,15 @@ genders_index_attrvals_functionality(int verbose)
 							   databases[i]->filename,
 							   verbose);
 		}
-      
+
 	      /* Test attr with val, but invalid val */
 	      if (databases[i]->data->attr_with_val)
 		{
-		  return_value = genders_isattrval(handle, 
+		  return_value = genders_isattrval(handle,
 						   databases[i]->data->attr_with_val,
 						   GENDERS_DATABASE_INVALID_VAL);
 		  errnum = genders_errnum(handle);
-		  
+
 		  err += genders_return_value_errnum_check("genders_index_attrvals:genders_isattrval",
 							   num,
 							   0,
@@ -2257,13 +2257,13 @@ genders_index_attrvals_functionality(int verbose)
 							   verbose);
 		}
 	    }
-	  
+
 	  errcount += err;
 	}
-      
+
       if (genders_handle_destroy(handle) < 0)
 	genders_err_exit("genders_handle_destroy");
-      
+
       num++;
       i++;
     }
@@ -2284,16 +2284,16 @@ genders_query_functionality(int verbose)
     int nodelist_len, return_value, errnum, err;
     char **nodelist;
     int i = 0;
-      
+
     if (!(handle = genders_handle_create()))
       genders_err_exit("genders_handle_create");
-	
+
     if (genders_load_data(handle, genders_database_base.filename) < 0)
       genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
-    if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0) 
+
+    if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0)
       genders_err_exit("genders_nodelist_create: %s", genders_errormsg(handle));
-	
+
     while (genders_query_parse_error_tests[i] != NULL)
       {
 	return_value = genders_query(handle,
@@ -2301,7 +2301,7 @@ genders_query_functionality(int verbose)
 				     nodelist_len,
 				     genders_query_parse_error_tests[i]);
 	errnum = genders_errnum(handle);
-	
+
 	sprintf(msgbuf, "\"%s\"", genders_query_parse_error_tests[i]);
 	err = genders_return_value_errnum_check("genders_query",
 						num,
@@ -2331,21 +2331,21 @@ genders_query_functionality(int verbose)
       {
 	int j, nodelist_len, return_value, errnum, err;
 	char **nodelist;
-      
+
 	if (!(handle = genders_handle_create()))
 	  genders_err_exit("genders_handle_create");
-	
+
 	if (genders_load_data(handle, databases[i]->filename) < 0)
 	  genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
-	if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0) 
+
+	if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0)
 	  genders_err_exit("genders_nodelist_create: %s", genders_errormsg(handle));
-	
+
 	for (j = 0; j < databases[i]->data->attrval_nodes_len; j++)
 	  {
 	    char querybuf[GENDERS_QUERY_BUFLEN];
 	    char *queryptr;
-	    
+
 	    /* Construct simple query */
 	    if (databases[i]->data->attrval_nodes[j].attr
 		&& strlen(databases[i]->data->attrval_nodes[j].attr))
@@ -2362,13 +2362,13 @@ genders_query_functionality(int verbose)
 	      }
 	    else
 	      queryptr = NULL;
-	     
-	    return_value = genders_query(handle, 
+
+	    return_value = genders_query(handle,
 					 nodelist,
 					 nodelist_len,
 					 queryptr);
 	    errnum = genders_errnum(handle);
-	    
+
 	    err = genders_return_value_errnum_list_check("genders_query",
 							 num,
 							 databases[i]->data->attrval_nodes[j].nodeslen,
@@ -2382,17 +2382,17 @@ genders_query_functionality(int verbose)
 							 GENDERS_COMPARISON_MATCH,
 							 databases[i]->filename,
 							 verbose);
-	    
+
 	    errcount += err;
 	  }
-	
+
 	/* Test invalid attr */
-	return_value = genders_query(handle, 
+	return_value = genders_query(handle,
 				     nodelist,
 				     nodelist_len,
 				     GENDERS_DATABASE_INVALID_ATTR);
 	errnum = genders_errnum(handle);
-	
+
 	err = genders_return_value_errnum_check("genders_query",
 						num,
 						0,
@@ -2407,7 +2407,7 @@ genders_query_functionality(int verbose)
 	if (databases[i]->data->attr_with_val)
 	  {
 	    char querybuf[GENDERS_QUERY_BUFLEN];
-	    
+
 	    memset(querybuf, '\0', GENDERS_QUERY_BUFLEN);
 	    strcpy(querybuf, databases[i]->data->attr_with_val);
 	    strcat(querybuf, "=");
@@ -2418,8 +2418,8 @@ genders_query_functionality(int verbose)
 					 nodelist_len,
 					 querybuf);
 	    errnum = genders_errnum(handle);
-	  
-            sprintf(msgbuf, "%s: \"%s\"", 
+
+            sprintf(msgbuf, "%s: \"%s\"",
                     databases[i]->filename,
                     querybuf);
 
@@ -2438,7 +2438,7 @@ genders_query_functionality(int verbose)
 	  genders_err_exit("genders_nodelist_destroy: %s", genders_errormsg(handle));
 	if (genders_handle_destroy(handle) < 0)
 	  genders_err_exit("genders_handle_destroy");
-	
+
 	num++;
 	i++;
       }
@@ -2454,26 +2454,26 @@ genders_query_functionality(int verbose)
       {
 	int j, nodelist_len, return_value, errnum, err;
 	char **nodelist;
-      
+
 	if (!(handle = genders_handle_create()))
 	  genders_err_exit("genders_handle_create");
-	
+
 	if (genders_load_data(handle, databases[i]->filename) < 0)
 	  genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
-	if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0) 
+
+	if ((nodelist_len = genders_nodelist_create(handle, &nodelist)) < 0)
 	  genders_err_exit("genders_nodelist_create: %s", genders_errormsg(handle));
-	
+
 	j = 0;
 	while (databases[i]->tests->tests[j].query != NULL)
 	  {
-	    return_value = genders_query(handle, 
+	    return_value = genders_query(handle,
 					 nodelist,
 					 nodelist_len,
 					 databases[i]->tests->tests[j].query);
 	    errnum = genders_errnum(handle);
 
-	    sprintf(msgbuf, "%s: \"%s\"", 
+	    sprintf(msgbuf, "%s: \"%s\"",
 		    databases[i]->filename,
 		    databases[i]->tests->tests[j].query);
 	    err = genders_return_value_errnum_list_check("genders_query",
@@ -2489,7 +2489,7 @@ genders_query_functionality(int verbose)
 							 GENDERS_COMPARISON_MATCH,
 							 msgbuf,
 							 verbose);
-	    
+
 	    errcount += err;
 	    j++;
 	  }
@@ -2498,7 +2498,7 @@ genders_query_functionality(int verbose)
 	  genders_err_exit("genders_nodelist_destroy: %s", genders_errormsg(handle));
 	if (genders_handle_destroy(handle) < 0)
 	  genders_err_exit("genders_handle_destroy");
-	
+
 	num++;
 	i++;
       }
@@ -2519,20 +2519,20 @@ genders_testquery_functionality(int verbose)
     genders_t handle;
     int return_value, errnum, err;
     int i = 0;
-      
+
     if (!(handle = genders_handle_create()))
       genders_err_exit("genders_handle_create");
-	
+
     if (genders_load_data(handle, genders_database_base.filename) < 0)
       genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
     while (genders_query_parse_error_tests[i] != NULL)
       {
 	return_value = genders_testquery(handle,
                                          "node1",
                                          genders_query_parse_error_tests[i]);
 	errnum = genders_errnum(handle);
-	
+
 	sprintf(msgbuf, "\"%s\"", genders_query_parse_error_tests[i]);
 	err = genders_return_value_errnum_check("genders_testquery",
 						num,
@@ -2559,13 +2559,13 @@ genders_testquery_functionality(int verbose)
     while (databases[i] != NULL)
       {
 	int j, return_value, errnum, err;
-      
+
 	if (!(handle = genders_handle_create()))
 	  genders_err_exit("genders_handle_create");
-	
+
 	if (genders_load_data(handle, databases[i]->filename) < 0)
 	  genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
 	for (j = 0; j < databases[i]->data->attrval_nodes_len; j++)
 	  {
 	    char querybuf[GENDERS_QUERY_BUFLEN];
@@ -2590,8 +2590,8 @@ genders_testquery_functionality(int verbose)
                                                      databases[i]->data->attrval_nodes[j].nodes[k],
                                                      querybuf);
                     errnum = genders_errnum(handle);
-                    
-                    sprintf(msgbuf, "%s: \"%s\"", 
+
+                    sprintf(msgbuf, "%s: \"%s\"",
                             databases[i]->filename,
                             querybuf);
                     err = genders_return_value_errnum_check("genders_testquery",
@@ -2601,7 +2601,7 @@ genders_testquery_functionality(int verbose)
                                                             return_value,
                                                             errnum,
                                                             msgbuf,
-                                                            verbose);                    
+                                                            verbose);
                     errcount += err;
                   }
               }
@@ -2613,8 +2613,8 @@ genders_testquery_functionality(int verbose)
                                                  databases[i]->data->attrval_nodes[j].nodes[k],
                                                  GENDERS_DATABASE_INVALID_ATTR);
                 errnum = genders_errnum(handle);
-	
-                sprintf(msgbuf, "%s: \"%s\"", 
+
+                sprintf(msgbuf, "%s: \"%s\"",
                         databases[i]->filename,
                         GENDERS_DATABASE_INVALID_ATTR);
                 err = genders_return_value_errnum_check("genders_testquery",
@@ -2631,18 +2631,18 @@ genders_testquery_functionality(int verbose)
                 if (databases[i]->data->attr_with_val)
                   {
                     char querybuf2[GENDERS_QUERY_BUFLEN];
-                    
+
                     memset(querybuf2, '\0', GENDERS_QUERY_BUFLEN);
                     strcpy(querybuf2, databases[i]->data->attr_with_val);
                     strcat(querybuf2, "=");
                     strcat(querybuf2, GENDERS_DATABASE_INVALID_VAL);
-                    
+
                     return_value = genders_testquery(handle,
                                                      databases[i]->data->attrval_nodes[j].nodes[k],
                                                      querybuf2);
                     errnum = genders_errnum(handle);
-                    
-                    sprintf(msgbuf, "%s: \"%s\"", 
+
+                    sprintf(msgbuf, "%s: \"%s\"",
                             databases[i]->filename,
                             querybuf2);
                     err = genders_return_value_errnum_check("genders_testquery",
@@ -2660,7 +2660,7 @@ genders_testquery_functionality(int verbose)
 
 	if (genders_handle_destroy(handle) < 0)
 	  genders_err_exit("genders_handle_destroy");
-	
+
 	num++;
 	i++;
       }
@@ -2675,13 +2675,13 @@ genders_testquery_functionality(int verbose)
     while (databases[i] != NULL)
       {
 	int j, return_value, errnum, err;
-      
+
 	if (!(handle = genders_handle_create()))
 	  genders_err_exit("genders_handle_create");
-	
+
 	if (genders_load_data(handle, databases[i]->filename) < 0)
 	  genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
 	j = 0;
 	while (databases[i]->tests->tests[j].query != NULL)
 	  {
@@ -2691,15 +2691,15 @@ genders_testquery_functionality(int verbose)
 
                 for (k = 0; k < databases[i]->tests->tests[j].nodeslen; k++)
                   {
-                    return_value = genders_testquery(handle, 
+                    return_value = genders_testquery(handle,
                                                      databases[i]->tests->tests[j].nodes[k],
                                                      databases[i]->tests->tests[j].query);
                     errnum = genders_errnum(handle);
 
-                    sprintf(msgbuf, "%s: \"%s\"", 
+                    sprintf(msgbuf, "%s: \"%s\"",
                             databases[i]->filename,
                             databases[i]->tests->tests[j].query);
-                    
+
                     err = genders_return_value_errnum_check("genders_testquery",
                                                             num,
                                                             1,
@@ -2711,13 +2711,13 @@ genders_testquery_functionality(int verbose)
                     errcount += err;
                   }
               }
-	    
+
 	    j++;
 	  }
 
 	if (genders_handle_destroy(handle) < 0)
 	  genders_err_exit("genders_handle_destroy");
-	
+
 	num++;
 	i++;
       }
@@ -2738,7 +2738,7 @@ genders_parse_functionality(int verbose)
     genders_err_exit("dup: %s", strerror(errno));
   if ((dev_null = open(_PATH_DEVNULL, O_APPEND)) < 0)
     genders_err_exit("open: %s: %s", _PATH_DEVNULL, strerror(errno));
-  
+
   /* Part A: Successfully find parse errors */
   {
     int i = 0;
@@ -2831,17 +2831,17 @@ genders_set_errnum_functionality(int verbose)
 
   if (!(handle = genders_handle_create()))
     genders_err_exit("genders_handle_create");
-  
+
   if (genders_load_data(handle, genders_database_base.filename) < 0)
     genders_err_exit("genders_load_data: %s", genders_errormsg(handle));
-	
+
   for (i = GENDERS_ERR_SUCCESS; i <= GENDERS_ERR_ERRNUMRANGE; i++)
     {
       int errnum, err;
 
       genders_set_errnum(handle, i);
       errnum = genders_errnum(handle);
-	
+
       err = genders_errnum_check("genders_set_errnum",
 				 num,
 				 i,
@@ -2890,10 +2890,10 @@ genders_copy_functionality(int verbose)
       int errnum;
       int err = 0;
       int j, k;
-      
+
       if (!(handleorig = genders_handle_create()))
 	genders_err_exit("genders_handle_create");
-      
+
       if (genders_load_data(handleorig, databases[i]->filename) < 0)
 	genders_err_exit("genders_load_data: %s", genders_errormsg(handleorig));
 
@@ -2909,9 +2909,9 @@ genders_copy_functionality(int verbose)
 						      errnum,
 						      databases[i]->filename,
 						      verbose);
-      
+
       errcount +=err;
-      
+
       if (err)
 	goto try_next_database;
 
@@ -2921,90 +2921,90 @@ genders_copy_functionality(int verbose)
 	genders_err_exit("genders_getnumnodes: %s", genders_errormsg(handleorig));
       if ((numnodescopy = genders_getnumnodes(handlecopy)) < 0)
 	genders_err_exit("genders_getnumnodes: %s", genders_errormsg(handlecopy));
-      
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       numnodesorig,
 				       numnodescopy,
 				       "numnodes",
 				       verbose);
-      
+
       err += errcount;
 
       if ((numattrsorig = genders_getnumattrs(handleorig)) < 0)
 	genders_err_exit("genders_getnumattrs: %s", genders_errormsg(handleorig));
       if ((numattrscopy = genders_getnumattrs(handlecopy)) < 0)
 	genders_err_exit("genders_getnumattrs: %s", genders_errormsg(handlecopy));
-      
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       numattrsorig,
 				       numattrscopy,
 				       "numattrs",
 				       verbose);
-      
+
       err += errcount;
 
       if ((maxattrsorig = genders_getmaxattrs(handleorig)) < 0)
 	genders_err_exit("genders_getmaxattrs: %s", genders_errormsg(handleorig));
       if ((maxattrscopy = genders_getmaxattrs(handlecopy)) < 0)
 	genders_err_exit("genders_getmaxattrs: %s", genders_errormsg(handlecopy));
-      
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       maxattrsorig,
 				       maxattrscopy,
 				       "maxattrs",
 				       verbose);
-      
+
       err += errcount;
 
       if ((maxnodelenorig = genders_getmaxnodelen(handleorig)) < 0)
 	genders_err_exit("genders_getmaxnodelen: %s", genders_errormsg(handleorig));
       if ((maxnodelencopy = genders_getmaxnodelen(handlecopy)) < 0)
 	genders_err_exit("genders_getmaxnodelen: %s", genders_errormsg(handlecopy));
-      
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       maxnodelenorig,
 				       maxnodelencopy,
 				       "maxnodelen",
 				       verbose);
-      
+
       err += errcount;
 
       if ((maxattrlenorig = genders_getmaxattrlen(handleorig)) < 0)
 	genders_err_exit("genders_getmaxattrlen: %s", genders_errormsg(handleorig));
       if ((maxattrlencopy = genders_getmaxattrlen(handlecopy)) < 0)
 	genders_err_exit("genders_getmaxattrlen: %s", genders_errormsg(handlecopy));
-      
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       maxattrlenorig,
 				       maxattrlencopy,
 				       "maxattrlen",
 				       verbose);
-      
+
       err += errcount;
 
       if ((maxvallenorig = genders_getmaxvallen(handleorig)) < 0)
 	genders_err_exit("genders_getmaxvallen: %s", genders_errormsg(handleorig));
       if ((maxvallencopy = genders_getmaxvallen(handlecopy)) < 0)
 	genders_err_exit("genders_getmaxvallen: %s", genders_errormsg(handlecopy));
-      
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       maxvallenorig,
 				       maxvallencopy,
 				       "maxvallen",
 				       verbose);
-      
+
       err += errcount;
 
-      if ((nodelist_lenorig = genders_nodelist_create(handleorig, &nodelistorig)) < 0) 
+      if ((nodelist_lenorig = genders_nodelist_create(handleorig, &nodelistorig)) < 0)
 	genders_err_exit("genders_nodelist_create: %s", genders_errormsg(handleorig));
 
-      if ((nodelist_lencopy = genders_nodelist_create(handlecopy, &nodelistcopy)) < 0) 
+      if ((nodelist_lencopy = genders_nodelist_create(handlecopy, &nodelistcopy)) < 0)
 	genders_err_exit("genders_nodelist_create: %s", genders_errormsg(handlecopy));
 
       err = genders_return_value_check("genders_copy",
@@ -3013,13 +3013,13 @@ genders_copy_functionality(int verbose)
 				       nodelist_lencopy,
 				       "nodelist_len",
 				       verbose);
-      
+
       err += errcount;
 
-      if ((attrlist_lenorig = genders_attrlist_create(handleorig, &attrlistorig)) < 0) 
+      if ((attrlist_lenorig = genders_attrlist_create(handleorig, &attrlistorig)) < 0)
 	genders_err_exit("genders_attrlist_create: %s", genders_errormsg(handleorig));
 
-      if ((attrlist_lencopy = genders_attrlist_create(handlecopy, &attrlistcopy)) < 0) 
+      if ((attrlist_lencopy = genders_attrlist_create(handlecopy, &attrlistcopy)) < 0)
 	genders_err_exit("genders_attrlist_create: %s", genders_errormsg(handlecopy));
 
       err = genders_return_value_check("genders_copy",
@@ -3028,22 +3028,22 @@ genders_copy_functionality(int verbose)
 				       attrlist_lencopy,
 				       "attrlist_len",
 				       verbose);
-      
+
       err += errcount;
 
-      if ((vallist_lenorig = genders_vallist_create(handleorig, &vallistorig)) < 0) 
+      if ((vallist_lenorig = genders_vallist_create(handleorig, &vallistorig)) < 0)
 	genders_err_exit("genders_vallist_create: %s", genders_errormsg(handleorig));
 
-      if ((vallist_lencopy = genders_vallist_create(handlecopy, &vallistcopy)) < 0) 
+      if ((vallist_lencopy = genders_vallist_create(handlecopy, &vallistcopy)) < 0)
 	genders_err_exit("genders_vallist_create: %s", genders_errormsg(handlecopy));
-	    
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       vallist_lenorig,
 				       vallist_lencopy,
 				       "vallist_len",
 				       verbose);
-      
+
       err += errcount;
 
       if ((nodelist_countorig = genders_getnodes(handleorig,
@@ -3059,14 +3059,14 @@ genders_copy_functionality(int verbose)
 						 NULL,
 						 NULL)) < 0)
 	genders_err_exit("genders_getnodes: %s", genders_errormsg(handlecopy));
-     
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       nodelist_countorig,
 				       nodelist_countcopy,
 				       "nodelist_count",
 				       verbose);
-      
+
       err += errcount;
 
       for (j = 0; j < nodelist_countorig; j++)
@@ -3092,28 +3092,28 @@ genders_copy_functionality(int verbose)
 
 	      if (genders_attrlist_clear(handleorig, attrlistorig) < 0)
 		genders_err_exit("genders_attrlist_clear: %s", genders_errormsg(handleorig));
-	      
+
 	      if (genders_attrlist_clear(handlecopy, attrlistcopy) < 0)
 		genders_err_exit("genders_attrlist_clear: %s", genders_errormsg(handlecopy));
-	      
+
 	      if (genders_vallist_clear(handleorig, vallistorig) < 0)
 		genders_err_exit("genders_vallist_clear: %s", genders_errormsg(handleorig));
-	      
+
 	      if (genders_vallist_clear(handlecopy, vallistcopy) < 0)
 		genders_err_exit("genders_vallist_clear: %s", genders_errormsg(handlecopy));
-	      
+
 	      countorig = genders_getattr(handleorig,
 					  attrlistorig,
 					  vallistorig,
 					  attrlist_lenorig,
 					  nodelistorig[j]);
-	      
+
 	      countcopy = genders_getattr(handlecopy,
 					  attrlistcopy,
 					  vallistcopy,
 					  attrlist_lencopy,
 					  nodelistcopy[j]);
-	      
+
 	      err = genders_return_value_check("genders_copy",
 					       num,
 					       countorig,
@@ -3136,7 +3136,7 @@ genders_copy_functionality(int verbose)
 						 "copy",
 						 "getattr attr listing",
 						 verbose);
-		      
+
 		      err += errcount;
 
 		      err = genders_string_check("genders_copy",
@@ -3147,13 +3147,13 @@ genders_copy_functionality(int verbose)
 						 "copy",
 						 "getattr val listing",
 						 verbose);
-		      
+
 		      err += errcount;
 		    }
 		}
 	    }
 	}
-      
+
       if (genders_attrlist_clear(handleorig, attrlistorig) < 0)
 	genders_err_exit("genders_attrlist_clear: %s", genders_errormsg(handleorig));
 
@@ -3169,16 +3169,16 @@ genders_copy_functionality(int verbose)
 						    attrlistcopy,
 						    attrlist_lencopy)) < 0)
 	genders_err_exit("genders_getattr_all: %s", genders_errormsg(handlecopy));
-      
+
       err = genders_return_value_check("genders_copy",
 				       num,
 				       attrlist_countorig,
 				       attrlist_countcopy,
 				       "attrlist_count",
 				       verbose);
-      
+
       err += errcount;
-      
+
       for (j = 0; j < attrlist_countorig; j++)
 	{
 	  err = genders_string_check("genders_copy",
@@ -3216,7 +3216,7 @@ genders_copy_functionality(int verbose)
     try_next_database:
       if (genders_handle_destroy(handleorig) < 0)
 	genders_err_exit("genders_handle_destroy");
-      
+
       num++;
       i++;
     }

--- a/src/testsuite/libgenders/genders_test_query_tests.c
+++ b/src/testsuite/libgenders/genders_test_query_tests.c
@@ -29,7 +29,7 @@
 
 #include "genders_test_query_tests.h"
 
-char *genders_query_parse_error_tests[] = 
+char *genders_query_parse_error_tests[] =
   {
     "~",
     "(",
@@ -51,8 +51,8 @@ char *genders_query_parse_error_tests[] =
 genders_query_tests_t genders_query_functionality_tests_query_1_tests =
   {
     {
-      /* 
-       * Simple tests 
+      /*
+       * Simple tests
        */
       {
 	"attr1",
@@ -129,7 +129,7 @@ genders_query_tests_t genders_query_functionality_tests_query_1_tests =
 	{"node2", "node4", "node6", "node8", NULL},
 	4,
       },
-      /* 
+      /*
        * Empty sets
        */
       {
@@ -253,8 +253,8 @@ genders_query_tests_t genders_query_functionality_tests_query_1_tests =
 	0,
       },
 
-      /* 
-       * Complex tests - all nodes 
+      /*
+       * Complex tests - all nodes
        */
       /* binary operations */
       {
@@ -399,8 +399,8 @@ genders_query_tests_t genders_query_functionality_tests_query_1_tests =
 	{"node1", "node2", "node3", "node4", "node5", "node6", "node7", "node8", NULL},
 	8,
       },
-      /* 
-       * Complex tests - half nodes 
+      /*
+       * Complex tests - half nodes
        */
       {
 	"attr1&&attr3",
@@ -716,7 +716,7 @@ genders_query_tests_t genders_query_functionality_tests_query_1_tests =
 	"attr2=val2&&attr10=val10",
 	{"node2", "node4", "node6", "node8", NULL},
 	4,
-      }, 
+      },
       {
 	"attr1--attr7",
 	{"node2", "node4", "node6", "node8", NULL},
@@ -877,19 +877,19 @@ genders_query_tests_t genders_query_functionality_tests_query_1_tests =
     }
   };
 
-genders_query_functionality_tests_t genders_query_functionality_tests_query_1 = 
+genders_query_functionality_tests_t genders_query_functionality_tests_query_1 =
   {
     "testdatabases/genders.query_1",
     &genders_query_functionality_tests_query_1_tests,
   };
 
-genders_query_functionality_tests_t genders_query_functionality_tests_query_1_comma = 
+genders_query_functionality_tests_t genders_query_functionality_tests_query_1_comma =
   {
     "testdatabases/genders.query_1_comma",
     &genders_query_functionality_tests_query_1_tests,
   };
 
-genders_query_functionality_tests_t genders_query_functionality_tests_query_1_hostrange = 
+genders_query_functionality_tests_t genders_query_functionality_tests_query_1_hostrange =
   {
     "testdatabases/genders.query_1_hostrange",
     &genders_query_functionality_tests_query_1_tests,
@@ -897,9 +897,9 @@ genders_query_functionality_tests_t genders_query_functionality_tests_query_1_ho
 
 genders_query_tests_t genders_query_functionality_tests_query_2_tests =
   {
-    { 
-      /* 
-       * Simple tests 
+    {
+      /*
+       * Simple tests
        */
       {
 	"attr1",
@@ -996,7 +996,7 @@ genders_query_tests_t genders_query_functionality_tests_query_2_tests =
 	{"node8", NULL},
 	1,
       },
-      /* 
+      /*
        * Empty sets
        */
       {
@@ -1219,8 +1219,8 @@ genders_query_tests_t genders_query_functionality_tests_query_2_tests =
 	{NULL},
 	0,
       },
-      /* 
-       * Complex tests - all nodes 
+      /*
+       * Complex tests - all nodes
        */
       {
 	"attr2=valB||attr2=valC",
@@ -1608,8 +1608,8 @@ genders_query_tests_t genders_query_functionality_tests_query_2_tests =
 	{"node1", "node2", "node3", "node4", "node5", "node6", "node7", "node8", NULL},
 	8,
       },
-      /* 
-       * Complex tests - half nodes 
+      /*
+       * Complex tests - half nodes
        */
       {
 	"attr3=valD||attr3=valE",
@@ -2081,8 +2081,8 @@ genders_query_tests_t genders_query_functionality_tests_query_2_tests =
 	{"node2", "node4", "node6", "node8", NULL},
 	4,
       },
-      /* 
-       * Complex tests - quarter nodes 
+      /*
+       * Complex tests - quarter nodes
        */
       {
 	"attr1&&attr3=valD",
@@ -2432,19 +2432,19 @@ genders_query_tests_t genders_query_functionality_tests_query_2_tests =
     }
   };
 
-genders_query_functionality_tests_t genders_query_functionality_tests_query_2 = 
+genders_query_functionality_tests_t genders_query_functionality_tests_query_2 =
   {
     "testdatabases/genders.query_2",
     &genders_query_functionality_tests_query_2_tests,
   };
 
-genders_query_functionality_tests_t genders_query_functionality_tests_query_2_comma = 
+genders_query_functionality_tests_t genders_query_functionality_tests_query_2_comma =
   {
     "testdatabases/genders.query_2_comma",
     &genders_query_functionality_tests_query_2_tests,
   };
 
-genders_query_functionality_tests_t genders_query_functionality_tests_query_2_hostrange = 
+genders_query_functionality_tests_t genders_query_functionality_tests_query_2_hostrange =
   {
     "testdatabases/genders.query_2_hostrange",
     &genders_query_functionality_tests_query_2_tests,
@@ -2453,8 +2453,8 @@ genders_query_functionality_tests_t genders_query_functionality_tests_query_2_ho
 genders_query_tests_t genders_query_functionality_tests_query_special_chars_tests =
   {
     {
-      /* 
-       * Simple tests 
+      /*
+       * Simple tests
        */
       {
 	"attr%percent",
@@ -2590,7 +2590,7 @@ genders_query_tests_t genders_query_functionality_tests_query_special_chars_test
     }
   };
 
-genders_query_functionality_tests_t genders_query_functionality_tests_query_special_chars = 
+genders_query_functionality_tests_t genders_query_functionality_tests_query_special_chars =
   {
     "testdatabases/genders.query_special_chars",
     &genders_query_functionality_tests_query_special_chars_tests,
@@ -2599,8 +2599,8 @@ genders_query_functionality_tests_t genders_query_functionality_tests_query_spec
 genders_query_tests_t genders_query_functionality_tests_bugzilla414_1_tests =
   {
     {
-      /* 
-       * Simple tests 
+      /*
+       * Simple tests
        */
       {
 	"a&&b",
@@ -2624,8 +2624,8 @@ genders_query_functionality_tests_t genders_query_functionality_tests_bugzilla41
 genders_query_tests_t genders_query_functionality_tests_bugzilla414_2_tests =
   {
     {
-      /* 
-       * Simple tests 
+      /*
+       * Simple tests
        */
       {
 	"~b",
@@ -2649,8 +2649,8 @@ genders_query_functionality_tests_t genders_query_functionality_tests_bugzilla41
 genders_query_tests_t genders_query_functionality_tests_bugzilla414_3_tests =
   {
     {
-      /* 
-       * Simple tests 
+      /*
+       * Simple tests
        */
       {
 	"~b",
@@ -2674,8 +2674,8 @@ genders_query_functionality_tests_t genders_query_functionality_tests_bugzilla41
 genders_query_tests_t genders_query_functionality_tests_bugzilla414_4_tests =
   {
     {
-      /* 
-       * Simple tests 
+      /*
+       * Simple tests
        */
       {
 	"a&&b",
@@ -2699,8 +2699,8 @@ genders_query_functionality_tests_t genders_query_functionality_tests_bugzilla41
 genders_query_tests_t genders_query_functionality_tests_bugzilla414_5_tests =
   {
     {
-      /* 
-       * Simple tests 
+      /*
+       * Simple tests
        */
       {
 	"a&&b",

--- a/src/testsuite/libgenders/genders_testlib.c
+++ b/src/testsuite/libgenders/genders_testlib.c
@@ -58,7 +58,7 @@ genders_err_exit(char *fmt, ...)
   exit(1);
 }
 
-void 
+void
 genders_pass_output(char *funcname,
 		    int num,
 		    int err,
@@ -66,20 +66,20 @@ genders_pass_output(char *funcname,
 		    int verbose)
 {
   assert(funcname);
-  
+
   if (err)
     return;
 
   if (verbose > 1)
     {
       if (msg)
-	fprintf(stderr, 
+	fprintf(stderr,
 		"%s(%d): %s: PASS\n",
 		funcname,
 		num,
 		msg);
       else
-      fprintf(stderr, 
+      fprintf(stderr,
 	      "%s(%d): PASS\n",
 	      funcname,
 	      num);
@@ -97,9 +97,9 @@ genders_val_check(char *funcname,
 		  int verbose)
 {
   int err = 0;
-  
+
   assert(funcname && expected_val_str && val_str);
-  
+
   if (val != expected_val)
     {
       if (verbose)
@@ -129,7 +129,7 @@ genders_val_check(char *funcname,
   return err;
 }
 
-static int 
+static int
 _genders_val_check(char *funcname,
 		   int num,
 		   int expected_val,
@@ -148,7 +148,7 @@ _genders_val_check(char *funcname,
       if (verbose)
 	{
 	  if (msg)
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): %s: FAIL: %s=%d, %s=%d\n",
 		    funcname,
 		    num,
@@ -158,7 +158,7 @@ _genders_val_check(char *funcname,
 		    expected_val_str,
 		    expected_val);
 	  else
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): FAIL: %s=%d, %s=%d\n",
 		    funcname,
 		    num,
@@ -172,7 +172,7 @@ _genders_val_check(char *funcname,
   return err;
 }
 
-static int 
+static int
 _genders_pointer_check(char *funcname,
 		       int num,
 		       int expected_val,
@@ -185,7 +185,7 @@ _genders_pointer_check(char *funcname,
   int err = 0;
 
   assert(funcname && expected_val_str && val_str);
-  
+
   if (!((expected_val == GENDERS_POINTER_NULL
 	 && val == NULL)
 	|| (expected_val == GENDERS_POINTER_NON_NULL
@@ -194,7 +194,7 @@ _genders_pointer_check(char *funcname,
       if (verbose)
 	{
 	  if (msg)
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): %s: FAIL: %s=%p, %s=%s\n",
 		    funcname,
 		    num,
@@ -204,7 +204,7 @@ _genders_pointer_check(char *funcname,
 		    expected_val_str,
 		    (expected_val == GENDERS_POINTER_NULL) ? "NULL" : "Non-NULL");
 	  else
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): FAIL: %s=%p, %s=%s\n",
 		    funcname,
 		    num,
@@ -218,7 +218,7 @@ _genders_pointer_check(char *funcname,
   return err;
 }
 
-static int 
+static int
 _genders_string_check(char *funcname,
 		      int num,
 		      char *expected_string,
@@ -239,7 +239,7 @@ _genders_string_check(char *funcname,
       if (verbose)
 	{
 	  if (msg)
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): %s: FAIL: %s=%s, %s=%s\n",
 		    funcname,
 		    num,
@@ -249,7 +249,7 @@ _genders_string_check(char *funcname,
 		    expected_string_str,
 		    (expected_string) ? expected_string : "NULL");
 	  else
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): FAIL: %s=%s, %s=%s\n",
 		    funcname,
 		    num,
@@ -263,7 +263,7 @@ _genders_string_check(char *funcname,
   return err;
 }
 
-int 
+int
 genders_pointer_check(char *funcname,
 		      int num,
 		      void *expected_pointer,
@@ -282,7 +282,7 @@ genders_pointer_check(char *funcname,
       if (verbose)
 	{
 	  if (msg)
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): %s: FAIL: %s=%p, %s=%p\n",
 		    funcname,
 		    num,
@@ -292,7 +292,7 @@ genders_pointer_check(char *funcname,
 		    expected_pointer_str,
 		    expected_pointer);
 	  else
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): FAIL: %s=%p, %s=%p\n",
 		    funcname,
 		    num,
@@ -307,7 +307,7 @@ genders_pointer_check(char *funcname,
   return err;
 }
 
-int 
+int
 genders_pointer_exist_check(char *funcname,
 			    int num,
 			    void *pointer,
@@ -326,7 +326,7 @@ genders_pointer_exist_check(char *funcname,
       if (verbose)
 	{
 	  if (msg)
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): %s: FAIL: %s=%p, expected=%s\n",
 		    funcname,
 		    num,
@@ -335,7 +335,7 @@ genders_pointer_exist_check(char *funcname,
 		    pointer,
 		    (expected_null) ? "NULL" : "Non-NULL");
 	  else
-	    fprintf(stderr, 
+	    fprintf(stderr,
 		    "%s(%d): FAIL: %s=%p, expected=%s\n",
 		    funcname,
 		    num,
@@ -376,7 +376,7 @@ int genders_string_check(char *funcname,
 
 int
 genders_return_value_check(char *funcname,
-			   int num, 
+			   int num,
 			   int expected_return_value,
 			   int return_value,
 			   char *msg,
@@ -400,7 +400,7 @@ genders_return_value_check(char *funcname,
 
 int
 genders_errnum_check(char *funcname,
-		     int num, 
+		     int num,
 		     int expected_errnum,
 		     int errnum,
 		     char *msg,
@@ -424,7 +424,7 @@ genders_errnum_check(char *funcname,
 
 int
 genders_return_value_errnum_check(char *funcname,
-				  int num, 
+				  int num,
 				  int expected_return_value,
 				  int expected_errnum,
 				  int return_value,
@@ -435,7 +435,7 @@ genders_return_value_errnum_check(char *funcname,
   int err = 0;
 
   assert(funcname);
-  
+
   err += _genders_val_check(funcname,
 			    num,
 			    expected_return_value,
@@ -459,7 +459,7 @@ genders_return_value_errnum_check(char *funcname,
 
 int
 genders_return_value_pointer_errnum_check(char *funcname,
-					  int num, 
+					  int num,
 					  int expected_return_value,
 					  int expected_errnum,
 					  void *return_value,
@@ -470,7 +470,7 @@ genders_return_value_pointer_errnum_check(char *funcname,
   int err = 0;
 
   assert(funcname);
-  
+
   err += _genders_pointer_check(funcname,
 				num,
 				expected_return_value,
@@ -494,7 +494,7 @@ genders_return_value_pointer_errnum_check(char *funcname,
 
 int
 genders_return_value_errnum_string_check(char *funcname,
-					 int num, 
+					 int num,
 					 int expected_return_value,
 					 int expected_errnum,
 					 char *expected_string,
@@ -507,7 +507,7 @@ genders_return_value_errnum_string_check(char *funcname,
   int err = 0;
 
   assert(funcname);
-  
+
   err += _genders_val_check(funcname,
 			    num,
 			    expected_return_value,
@@ -539,7 +539,7 @@ genders_return_value_errnum_string_check(char *funcname,
 
 int
 genders_return_value_errnum_list_check(char *funcname,
-				       int num, 
+				       int num,
 				       int expected_return_value,
 				       int expected_errnum,
 				       char *expected_list[],
@@ -555,13 +555,13 @@ genders_return_value_errnum_list_check(char *funcname,
   int err = 0;
 
   assert(funcname
-	 && (comp_type == GENDERS_COMPARISON_MATCH 
+	 && (comp_type == GENDERS_COMPARISON_MATCH
 	     || comp_type == GENDERS_COMPARISON_CLEAR)
 	 && (!(comp_type == GENDERS_COMPARISON_MATCH) ||
 	     (comp_type == GENDERS_COMPARISON_MATCH && expected_list && list))
 	 && (!(comp_type == GENDERS_COMPARISON_CLEAR) ||
 	     (comp_type == GENDERS_COMPARISON_CLEAR && !expected_list && list)));
-  
+
   err += _genders_val_check(funcname,
 			    num,
 			    expected_return_value,
@@ -578,7 +578,7 @@ genders_return_value_errnum_list_check(char *funcname,
 			    "errnum",
 			    msg,
 			    verbose);
-	
+
   if (err == 0)
     {
       if (comp_type == GENDERS_COMPARISON_MATCH)
@@ -626,14 +626,14 @@ genders_return_value_errnum_list_check(char *funcname,
 				   verbose);
 	}
     }
-  
+
   genders_pass_output(funcname, num, err, msg, verbose);
   return err;
 }
 
 int
 genders_return_value_errnum_attrval_list_check(char *funcname,
-					       int num, 
+					       int num,
 					       int expected_return_value,
 					       int expected_errnum,
 					       char *expected_attrlist[],
@@ -650,7 +650,7 @@ genders_return_value_errnum_attrval_list_check(char *funcname,
   int err = 0;
 
   assert(funcname);
-  
+
   err += _genders_val_check(funcname,
 			    num,
 			    expected_return_value,
@@ -667,7 +667,7 @@ genders_return_value_errnum_attrval_list_check(char *funcname,
 			    "errnum",
 			    msg,
 			    verbose);
-	
+
   /* Step 1: Make sure every attr we're expected is in the attrlist */
   if (err == 0)
     {
@@ -715,7 +715,7 @@ genders_return_value_errnum_attrval_list_check(char *funcname,
 	    }
 	  if (val_index == -1)
 	    genders_err_exit("genders_return_value_errnum_attrval_list_check: fatal error");
-	  
+
 	  if (strcmp(expected_vallist[i], vallist[j]) == 0)
 	    match_flag++;
 
@@ -729,7 +729,7 @@ genders_return_value_errnum_attrval_list_check(char *funcname,
 				    verbose);
 	}
     }
-  
+
   genders_pass_output(funcname, num, err, msg, verbose);
   return err;
 }
@@ -743,9 +743,9 @@ genders_flag_check(char *funcname,
 		   int verbose)
 {
   int err = 0;
-  
+
   assert(funcname);
-  
+
   err += _genders_val_check(funcname,
                             num,
                             expected_flags,

--- a/src/testsuite/libgenders/genders_testlib.h
+++ b/src/testsuite/libgenders/genders_testlib.h
@@ -36,7 +36,7 @@ typedef enum {
   GENDERS_HANDLE_UNLOADED = 1,
   GENDERS_HANDLE_UNLOADED_DESTROYED = 2,
   GENDERS_HANDLE_LOADED = 3,
-  GENDERS_HANDLE_LOADED_DESTROYED = 4 
+  GENDERS_HANDLE_LOADED_DESTROYED = 4
 } genders_handle_type_t;
 
 typedef enum {
@@ -125,21 +125,21 @@ int genders_string_check(char *funcname,
 			 int verbose);
 
 int genders_return_value_check(char *funcname,
-			       int num, 
+			       int num,
 			       int expected_return_value,
 			       int ret,
 			       char *msg,
 			       int verbose);
 
 int genders_errnum_check(char *funcname,
-			 int num, 
+			 int num,
 			 int expected_errnum,
 			 int errnum,
 			 char *msg,
 			 int verbose);
 
 int genders_return_value_errnum_check(char *funcname,
-				      int num, 
+				      int num,
 				      int expected_return_value,
 				      int expected_errnum,
 				      int return_value,
@@ -148,7 +148,7 @@ int genders_return_value_errnum_check(char *funcname,
 				      int verbose);
 
 int genders_return_value_pointer_errnum_check(char *funcname,
-					      int num, 
+					      int num,
 					      int expected_return_value,
 					      int expected_errnum,
 					      void *return_value,
@@ -157,7 +157,7 @@ int genders_return_value_pointer_errnum_check(char *funcname,
 					      int verbose);
 
 int genders_return_value_errnum_string_check(char *funcname,
-					     int num, 
+					     int num,
 					     int expected_return_value,
 					     int expected_errnum,
 					     char *expected_string,
@@ -168,7 +168,7 @@ int genders_return_value_errnum_string_check(char *funcname,
 					     int verbose);
 
 int genders_return_value_errnum_list_check(char *funcname,
-					   int num, 
+					   int num,
 					   int expected_return_value,
 					   int expected_errnum,
 					   char *expected_list[],
@@ -182,7 +182,7 @@ int genders_return_value_errnum_list_check(char *funcname,
 					   int verbose);
 
 int genders_return_value_errnum_attrval_list_check(char *funcname,
-						   int num, 
+						   int num,
 						   int expected_return_value,
 						   int expected_errnum,
 						   char *expected_attrlist[],


### PR DESCRIPTION
Problem: There's a lot of trailing whitespace throughout the code and documentation.

Remove it.