### PR TITLE
nodeattr: increase hostlist buffer size

### DIFF
--- a/src/nodeattr/nodeattr.c
+++ b/src/nodeattr/nodeattr.c
@@ -106,7 +106,7 @@ static char *_node_create(genders_t gp);
 static char *_attr_create(genders_t gp);
 #endif
 
-#define HOSTLIST_BUFLEN 1024
+#define HOSTLIST_BUFLEN 65536
 
 int
 main(int argc, char *argv[])


### PR DESCRIPTION
Problem: As clusters get larger, some internal buffers used by hostlist API functions are now too small.

Increase the buffer used in nodeattr from 1K to 64K, matching what is used in libgenders.

Fixes #62