### PR TITLE
extensions: use setuptools over distutils

### DIFF
--- a/src/extensions/python/Makefile.am
+++ b/src/extensions/python/Makefile.am
@@ -17,13 +17,13 @@ all: genderssetup.py libgendersmodule.c genders.py
 	$(PYTHON) genderssetup.py build
 
 install:
-	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
+	$(PYTHON) genderssetup.py install --single-version-externally-managed --root=/ --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 pure_install:
-	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
+	$(PYTHON) genderssetup.py install --single-version-externally-managed --root=/ --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 install-data-local:
-	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
+	$(PYTHON) genderssetup.py install --single-version-externally-managed --root=/ --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 clean: 
 	rm -rf build

--- a/src/extensions/python/Makefile.in
+++ b/src/extensions/python/Makefile.in
@@ -489,13 +489,13 @@ uninstall-am:
 @WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py build
 
 @WITH_PYTHON_EXTENSIONS_TRUE@install:
-@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
+@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --single-version-externally-managed --root=/ --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 @WITH_PYTHON_EXTENSIONS_TRUE@pure_install:
-@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
+@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --single-version-externally-managed --root=/ --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 @WITH_PYTHON_EXTENSIONS_TRUE@install-data-local:
-@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
+@WITH_PYTHON_EXTENSIONS_TRUE@	$(PYTHON) genderssetup.py install --single-version-externally-managed --root=/ --prefix=$(PYTHON_DESTDIR)$(prefix) --exec-prefix=$(PYTHON_DESTDIR)$(exec_prefix)
 
 @WITH_PYTHON_EXTENSIONS_TRUE@clean: 
 @WITH_PYTHON_EXTENSIONS_TRUE@	rm -rf build

--- a/src/extensions/python/genderssetup.py.in
+++ b/src/extensions/python/genderssetup.py.in
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 libgendersmodule = Extension('libgenders',
                              include_dirs = ['../../../config', '../../libgenders'],


### PR DESCRIPTION
Problem: distutils was deprecated in Python 3.10 and removed in Python 3.12.

Use setuptools instead.

Adjust calls to setup.py in python Makefile.am as needed, re-autogen.

Fixes #65