### PR TITLE
libgenders/Makefile.am: Fix parallel build issue

### DIFF
--- a/src/libgenders/Makefile.am
+++ b/src/libgenders/Makefile.am
@@ -37,9 +37,8 @@ genders_query_parse.c: genders_query.c $(srcdir)/genders_query_parse.l
 genders_query.c: $(srcdir)/genders_query.y
 	$(YACC) -d -b genders_query $(srcdir)/genders_query.y
 
-# achu: -o option in yacc/bison is not portable, use -b instead
-genders_query.tab.c: $(srcdir)/genders_query.y
-	$(YACC) -d -b genders_query $(srcdir)/genders_query.y
+genders_query.tab.c: genders_query.c
+	touch genders_query.tab.c
 
 CLEANFILES = genders_query_parse.c genders_query.tab.c genders_query.tab.h
 


### PR DESCRIPTION
Two different `Makefile` rules are running the same `bison` command in parallel in parallel builds, creating the same files.

https://buildd.debian.org/status/fetch.php?pkg=genders&arch=mips64el&ver=1.27-3-2%2Bb1&stamp=1728948479&raw=0

```
...
bison -y -d -b genders_query ./genders_query.y
bison -y -d -b genders_query ./genders_query.y
...
genders_query.tab.c: In function 'yydestruct':
genders_query.tab.c:1468:3: error: 'YY_I' undeclared (first use in this function); did you mean 'YY_'?
 1468 |   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
      |   ^~~~
      |   YY_
...
```

Make one of the targets just depend on the other one.